### PR TITLE
Add repository consistency checks and CI; update docs and harden install/uninstall scripts

### DIFF
--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -1,0 +1,20 @@
+name: Repository Consistency
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  consistency:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Run repository consistency checks
+        run: ./scripts/check-consistency.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,15 +1,16 @@
 # Claude Onboarding Agent — Development Instructions
 
 ## What This Repo Is
-A Claude Code plugin with 8 skills (1 orchestrator + 7 setup skills). Skills are markdown files in `skills/*/SKILL.md`. The plugin generates configuration files (CLAUDE.md, AGENTS.md, etc.) in users' projects.
+A Claude Code plugin with 16 skills (onboarding, setup skills, and maintenance utilities). Skills are markdown files in `skills/*/SKILL.md`. The plugin generates configuration files (CLAUDE.md, AGENTS.md, etc.) in users' projects.
 
 ## Key Paths
 - `skills/` — all skill files (one folder per skill, each with a `SKILL.md`)
-- `.claude/commands/` — slash-command entry points
 - `.claude-plugin/plugin.json` — plugin manifest (registers skills and commands)
 - `scripts/install.sh` — GitHub installation script
 - `docs/superpowers/specs/` — design documents
 - `docs/superpowers/plans/` — implementation plans
+
+**Command registry source of truth:** slash commands are defined in `.claude-plugin/plugin.json` under `commands[]`. This repository currently does not use project-local `.claude/commands/` entrypoints.
 
 ## Adding a New Skill
 1. Create `skills/[skill-name]/SKILL.md`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,21 @@ New setup skills are the most valuable contribution. Each skill covers a use cas
 
 Open an issue first to discuss the change, especially for changes to the orchestrator or the Coding/Knowledge Base skills. Then submit a PR with a clear description.
 
+## Maintenance Changes
+
+Beyond adding new skills, maintenance updates are encouraged:
+
+- command catalog consistency across `README.md`, `.claude-plugin/plugin.json`, and `docs/RELEASE-NOTES.md`
+- installation and uninstall robustness (`scripts/install.sh`, `scripts/uninstall.sh`, PowerShell equivalents)
+- maintenance routing quality (`/checkup`, `/audit-setup`, `/upgrade-setup`, `/anchors`)
+- anchor update guardrails and workflow reliability
+
+Run this before opening a PR:
+
+```bash
+./scripts/check-consistency.sh
+```
+
 ## Standards
 
 - All SKILL.md content must be in English; skills respond in the user's detected language at runtime
@@ -34,3 +49,10 @@ Open an issue first to discuss the change, especially for changes to the orchest
 - Every skill must gracefully handle failed external dependency installation
 - Never silently overwrite an existing CLAUDE.md — always extend with a clearly delimited section
 - Keep skills focused: one use case per skill, 3–7 questions maximum
+
+## PR Checklist
+
+- [ ] Updated command references in docs where relevant (`README.md`, release notes, manifest)
+- [ ] Verified maintenance command behavior if touched (`/checkup`, `/audit-setup`, `/upgrade-setup`, `/anchors`)
+- [ ] Ran `./scripts/check-consistency.sh`
+- [ ] Included user-facing rationale and scope in the PR description

--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -1,5 +1,16 @@
 # Release Notes
 
+## v1.0.1 — 2026-04-24
+
+Documentation and maintenance update.
+
+### Improvements
+- Aligned release-notes command names with the current plugin command catalog
+- Clarified command registry source of truth in `CLAUDE.md`
+- Hardened install/uninstall scripts for safer symlink handling on macOS/Linux
+- Added a consistency check script and CI workflow to prevent manifest/docs drift
+- Expanded contributing guidance for maintenance changes and pre-PR checks
+
 ## v1.0.0 — 2026-04-16
 
 Initial release.
@@ -7,7 +18,7 @@ Initial release.
 ### Skills
 - `/onboarding` — Orchestrator with repo scanning and path inference
 - `/coding-setup` — Coding workflow with Superpowers integration
-- `/build-knowledge-base` — Karpathy-pattern knowledge base builder with Obsidian support
+- `/knowledge-base-setup` — Karpathy-pattern knowledge base builder with Obsidian support
 - `/office-setup` — Office and business productivity setup
 - `/research-setup` — Academic research and writing setup
-- `/content-creator-setup` — Content creation workflow setup
+- `/content-voice-setup` — Content creation workflow setup

--- a/scripts/check-consistency.sh
+++ b/scripts/check-consistency.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MANIFEST="$REPO_ROOT/.claude-plugin/plugin.json"
+README="$REPO_ROOT/README.md"
+RELEASE_NOTES="$REPO_ROOT/docs/RELEASE-NOTES.md"
+CLAUDE_DOC="$REPO_ROOT/CLAUDE.md"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required for consistency checks."
+  exit 1
+fi
+
+mapfile -t commands < <(jq -r '.commands[].name' "$MANIFEST")
+
+failed=0
+
+for cmd in "${commands[@]}"; do
+  if ! grep -q "\`/$cmd\`" "$README"; then
+    echo "ERROR: README is missing command /$cmd"
+    failed=1
+  fi
+done
+
+legacy_commands=(
+  "/build-knowledge-base"
+  "/content-creator-setup"
+)
+
+for legacy in "${legacy_commands[@]}"; do
+  if grep -q "$legacy" "$RELEASE_NOTES"; then
+    echo "ERROR: release notes still contain legacy command $legacy"
+    failed=1
+  fi
+done
+
+if grep -q '^- `\.claude/commands/`' "$CLAUDE_DOC"; then
+  echo "ERROR: CLAUDE.md still lists .claude/commands/ in key paths"
+  failed=1
+fi
+
+if [ "$failed" -ne 0 ]; then
+  exit 1
+fi
+
+echo "Consistency checks passed."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,6 +8,12 @@ REPO_URL="https://github.com/a2ngerer/claude_onboarding_agent.git"
 
 echo "Installing Claude Onboarding Agent..."
 
+if ! command -v git >/dev/null 2>&1; then
+  echo "git is required but not found on PATH."
+  echo "Install git and retry."
+  exit 1
+fi
+
 mkdir -p "$PLUGIN_DIR"
 mkdir -p "$SKILLS_DIR"
 
@@ -25,9 +31,16 @@ echo "Linking skills to ~/.claude/skills/..."
 for skill_dir in "$TARGET/skills"/*/; do
   skill_name=$(basename "$skill_dir")
   link_path="${SKILLS_DIR}/${skill_name}"
+
+  if [ -e "$link_path" ] && [ ! -L "$link_path" ]; then
+    echo "  ! ${skill_name} exists and is not a symlink — skipping"
+    continue
+  fi
+
   if [ -L "$link_path" ]; then
     rm "$link_path"
   fi
+
   ln -s "$skill_dir" "$link_path"
   echo "  ✓ ${skill_name}"
 done

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -5,14 +5,27 @@ PLUGIN_DIR="${HOME}/.claude/plugins"
 PLUGIN_NAME="claude-onboarding-agent"
 SKILLS_DIR="${HOME}/.claude/skills"
 TARGET="${PLUGIN_DIR}/${PLUGIN_NAME}"
+SKILLS_SOURCE="${TARGET}/skills"
 
 echo "Uninstalling Claude Onboarding Agent..."
 
 if [ -d "$TARGET" ]; then
-  for skill_dir in "$TARGET/skills"/*/; do
+  for skill_dir in "$SKILLS_SOURCE"/*/; do
     skill_name=$(basename "$skill_dir")
     link_path="${SKILLS_DIR}/${skill_name}"
     if [ -L "$link_path" ]; then
+      link_target="$(readlink "$link_path")"
+      if [[ "$link_target" != /* ]]; then
+        if ! link_target="$(cd "$(dirname "$link_path")" && cd "$link_target" && pwd -P 2>/dev/null)"; then
+          echo "  ! skipped skill: ${skill_name} (broken symlink)"
+          continue
+        fi
+      fi
+      expected_target="$(cd "$skill_dir" && pwd -P)"
+      if [ "$link_target" != "$expected_target" ]; then
+        echo "  ! skipped skill: ${skill_name} (symlink points outside plugin)"
+        continue
+      fi
       rm "$link_path"
       echo "  ✓ removed skill: ${skill_name}"
     fi


### PR DESCRIPTION
### Motivation

- Ensure manifest/docs/README consistency and prevent command/legacy drift by adding an automated repository check. 
- Surface the authoritative command registry and expand contributor guidance for maintenance and pre-PR checks. 
- Make install/uninstall more robust across environments by validating `git` presence and improving symlink handling. 

### Description

- Add a GitHub Actions workflow `/.github/workflows/consistency.yml` that runs `./scripts/check-consistency.sh` on `pull_request` and `push` to `main`. 
- Introduce `scripts/check-consistency.sh`, a `jq`-powered script that validates `.claude-plugin/plugin.json` commands are referenced in `README.md`, flags legacy commands in `docs/RELEASE-NOTES.md`, and ensures `CLAUDE.md` no longer refers to `.claude/commands/`. 
- Update `scripts/install.sh` to require `git` on PATH and skip linking when a skill path exists but is not a symlink. 
- Harden `scripts/uninstall.sh` to resolve relative symlinks, verify symlink targets point into the plugin before removal, and avoid removing unrelated links. 
- Update documentation files: `CLAUDE.md` (skill count, command registry note), `CONTRIBUTING.md` (maintenance guidance, pre-PR `./scripts/check-consistency.sh` step, PR checklist), and `docs/RELEASE-NOTES.md` (new entry with the maintenance and tooling changes). 

### Testing

- Ran `./scripts/check-consistency.sh` locally with `jq` installed and it completed with "Consistency checks passed."

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb793cfa90832794002f88939fdbe1)