### PR TITLE
June 2026 state-of-the-art refresh and skill trigger eval harness

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "claude-onboarding-agent",
+  "description": "Marketplace for the Claude Onboarding Agent plugin — guided setup skills that generate tailored CLAUDE.md, AGENTS.md, and config files for any use case.",
+  "owner": {
+    "name": "Alexander Angerer",
+    "email": "alexander.angerer@outlook.de"
+  },
+  "plugins": [
+    {
+      "name": "claude-onboarding-agent",
+      "source": "./",
+      "description": "Guided setup for Claude Code — generates tailored CLAUDE.md, AGENTS.md, and config files for any use case in minutes."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,8 @@
 {
   "name": "claude-onboarding-agent",
+  "displayName": "Claude Onboarding Agent",
   "description": "Guided setup for Claude Code — generates tailored CLAUDE.md, AGENTS.md, and config files for any use case in minutes.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Alexander Angerer",
     "email": "alexander.angerer@outlook.de"
@@ -26,39 +27,21 @@
     "productivity"
   ],
   "skills": [
-    "skills/onboarding/SKILL.md",
-    "skills/coding-setup/SKILL.md",
-    "skills/web-development-setup/SKILL.md",
-    "skills/data-science-setup/SKILL.md",
-    "skills/design-setup/SKILL.md",
-    "skills/knowledge-base-setup/SKILL.md",
-    "skills/devops-setup/SKILL.md",
-    "skills/content-voice-setup/SKILL.md",
-    "skills/office-setup/SKILL.md",
-    "skills/research-setup/SKILL.md",
-    "skills/academic-writing-setup/SKILL.md",
-    "skills/graphify-setup/SKILL.md",
-    "skills/audit-setup/SKILL.md",
-    "skills/upgrade-setup/SKILL.md",
-    "skills/checkup/SKILL.md",
-    "skills/anchors/SKILL.md"
-  ],
-  "commands": [
-    { "name": "onboarding", "skill": "onboarding" },
-    { "name": "coding-setup", "skill": "coding-setup" },
-    { "name": "web-development-setup", "skill": "web-development-setup" },
-    { "name": "data-science-setup", "skill": "data-science-setup" },
-    { "name": "design-setup", "skill": "design-setup" },
-    { "name": "knowledge-base-setup", "skill": "knowledge-base-setup" },
-    { "name": "devops-setup", "skill": "devops-setup" },
-    { "name": "content-voice-setup", "skill": "content-voice-setup" },
-    { "name": "office-setup", "skill": "office-setup" },
-    { "name": "research-setup", "skill": "research-setup" },
-    { "name": "academic-writing-setup", "skill": "academic-writing-setup" },
-    { "name": "graphify-setup", "skill": "graphify-setup" },
-    { "name": "audit-setup", "description": "Power-user tool — normally invoked via /checkup. Audit your current Claude setup and get a prioritized list of improvement suggestions.", "skill": "audit-setup" },
-    { "name": "upgrade-setup", "description": "Power-user tool — normally invoked via /checkup. Re-apply current best practices to an existing onboarding-agent setup with per-change confirmation, backups, and --dry-run.", "skill": "upgrade-setup" },
-    { "name": "checkup", "description": "Single maintenance entrypoint — runs /audit-setup internally, weighs findings + meta age + deprecated-model anchors, and routes to /onboarding --rebuild, /upgrade-setup, or a short fine-as-is summary.", "skill": "checkup" },
-    { "name": "anchors", "description": "Refresh anchor-derived marker sections in CLAUDE.md/AGENTS.md", "skill": "anchors" }
+    "./skills/onboarding",
+    "./skills/coding-setup",
+    "./skills/web-development-setup",
+    "./skills/data-science-setup",
+    "./skills/design-setup",
+    "./skills/knowledge-base-setup",
+    "./skills/devops-setup",
+    "./skills/content-voice-setup",
+    "./skills/office-setup",
+    "./skills/research-setup",
+    "./skills/academic-writing-setup",
+    "./skills/graphify-setup",
+    "./skills/audit-setup",
+    "./skills/upgrade-setup",
+    "./skills/checkup",
+    "./skills/anchors"
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "claude-onboarding-agent",
   "displayName": "Claude Onboarding Agent",
   "description": "Guided setup for Claude Code — generates tailored CLAUDE.md, AGENTS.md, and config files for any use case in minutes.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "Alexander Angerer",
     "email": "alexander.angerer@outlook.de"

--- a/.claude/agents/artifact-verifier.md
+++ b/.claude/agents/artifact-verifier.md
@@ -2,7 +2,7 @@
 name: artifact-verifier
 description: Read-only subagent that confirms a list of files exists on disk and passes lightweight structural checks (non-empty, valid JSON, expected delimiter). Returns one structured report; never writes files.
 tools: Bash, Glob, Grep, Read
-model: opus
+model: haiku
 ---
 
 # Artifact Verifier

--- a/.claude/agents/audit-collector.md
+++ b/.claude/agents/audit-collector.md
@@ -2,7 +2,7 @@
 name: audit-collector
 description: Read-only subagent that runs an audit skill (default `/audit-setup`) and returns a compact severity-bucketed finding summary. Wraps the audit skill; never writes files.
 tools: Bash, Glob, Grep, Read
-model: opus
+model: sonnet
 ---
 
 # Audit Collector

--- a/.claude/agents/repo-scanner.md
+++ b/.claude/agents/repo-scanner.md
@@ -2,7 +2,7 @@
 name: repo-scanner
 description: Read-only subagent that scans a user project for language, framework, corpus-size, and use-case signals. Returns one structured report; never writes files.
 tools: Bash, Glob, Grep, Read
-model: opus
+model: haiku
 ---
 
 # Repo Scanner

--- a/.claude/agents/upgrade-planner.md
+++ b/.claude/agents/upgrade-planner.md
@@ -2,7 +2,7 @@
 name: upgrade-planner
 description: Read-only subagent that enumerates plugin-owned delimited sections in a user project, diffs each against the canonical current template, and returns the list of proposed changes. Never writes files.
 tools: Bash, Glob, Grep, Read
-model: opus
+model: sonnet
 ---
 
 # Upgrade Planner
@@ -86,7 +86,7 @@ Schema reference: `.claude/agents/schemas/upgrade-plan.schema.json`.
 
 ## Delimiter Recognition
 
-Match the delimiters exactly as documented in `skills/upgrade/SKILL.md` Pass 2:
+Match the delimiters exactly as documented in `skills/upgrade-setup/SKILL.md` Pass 2:
 
 - **Markdown** (`CLAUDE.md`, `AGENTS.md`, `.claude/rules/*.md`):
   - Attributed: `<!-- onboarding-agent:start setup=<type> skill=<slug> section=<name> -->` … `<!-- onboarding-agent:end -->`

--- a/.claude/hooks/check-dependencies.sh
+++ b/.claude/hooks/check-dependencies.sh
@@ -26,7 +26,7 @@ case "$REL" in
     ;;
   skills/*/SKILL.md)
     skill=$(printf '%s' "$REL" | sed -E 's#skills/([^/]+)/SKILL\.md#\1#')
-    emit "Skill '$skill' was modified. If this is a new skill or its frontmatter name/description changed, verify: (1) .claude-plugin/plugin.json lists its directory in skills[]. (2) skills/onboarding/SKILL.md offers it in Step 3 and Step 5. (3) README.md 'What's Inside' table includes it. (4) If it references the shared install protocol, variables match skills/_shared/installation-protocol.md."
+    emit "Skill '$skill' was modified. If this is a new skill or its frontmatter name/description changed, verify: (1) .claude-plugin/plugin.json lists its directory in skills[]. (2) skills/onboarding/SKILL.md offers it in Step 3 and Step 5. (3) README.md 'What's Inside' table includes it. (4) If it references the shared install protocol, variables match skills/_shared/installation-protocol.md. (5) The trigger-eval fixture evals/$skill.json still reflects the description — run scripts/run-skill-evals.sh --skill $skill after description changes."
     ;;
   .claude-plugin/plugin.json)
     emit "plugin.json was modified. If skills[] changed, verify: (1) every referenced skill directory contains a SKILL.md. (2) skills/onboarding/SKILL.md Step 3 and Step 5 still match. (3) README.md 'What's Inside' table still matches. (4) scripts/install.sh still works for the new skill set."

--- a/.claude/hooks/check-dependencies.sh
+++ b/.claude/hooks/check-dependencies.sh
@@ -9,7 +9,7 @@ INPUT=$(cat)
 FILE=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // .tool_response.filePath // empty' 2>/dev/null)
 [ -z "$FILE" ] && exit 0
 
-REPO="/Users/angeral/Repositories/claude_onboarding_agent"
+REPO="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}"
 REL="${FILE#$REPO/}"
 
 emit() {
@@ -18,18 +18,18 @@ emit() {
 }
 
 case "$REL" in
-  skills/_shared/installation.md)
-    emit "Shared installation protocol was modified. All 7 setup skills reference this file. Verify: (1) no setup skill (skills/coding-setup, knowledge-base-setup, office-setup, research-setup, content-voice-setup, devops-setup, design-setup) uses outdated step numbers (P1–P5) or variable names (e.g. \`superpowers_installed\`, \`superpowers_method\`, \`superpowers_scope\`). (2) docs/superpowers/specs/2026-04-17-installation-protocol.md still reflects the current contract."
+  skills/_shared/installation-protocol.md)
+    emit "Shared installation protocol was modified. All 10 setup skills reference this file. Verify: (1) no setup skill (skills/academic-writing-setup, skills/coding-setup, skills/content-voice-setup, skills/data-science-setup, skills/design-setup, skills/devops-setup, skills/knowledge-base-setup, skills/office-setup, skills/research-setup, skills/web-development-setup) uses outdated step numbers (P1–P5) or variable names (e.g. \`superpowers_installed\`, \`superpowers_method\`, \`superpowers_scope\`). (2) docs/superpowers/specs/2026-04-17-installation-protocol.md still reflects the current contract."
     ;;
   skills/onboarding/SKILL.md)
     emit "Orchestrator skill was modified. Verify: (1) every path it offers in Step 3 / Step 5 corresponds to an existing skill folder under skills/. (2) README.md 'What's Inside' table matches the path list."
     ;;
   skills/*/SKILL.md)
     skill=$(printf '%s' "$REL" | sed -E 's#skills/([^/]+)/SKILL\.md#\1#')
-    emit "Skill '$skill' was modified. If this is a new skill or its slash-command name/description changed, verify: (1) .claude-plugin/plugin.json lists it in skills[] AND commands[]. (2) skills/onboarding/SKILL.md offers it in Step 3 and Step 5. (3) README.md 'What's Inside' table includes it. (4) If it references the shared install protocol, variables match skills/_shared/installation.md."
+    emit "Skill '$skill' was modified. If this is a new skill or its frontmatter name/description changed, verify: (1) .claude-plugin/plugin.json lists its directory in skills[]. (2) skills/onboarding/SKILL.md offers it in Step 3 and Step 5. (3) README.md 'What's Inside' table includes it. (4) If it references the shared install protocol, variables match skills/_shared/installation-protocol.md."
     ;;
   .claude-plugin/plugin.json)
-    emit "plugin.json was modified. If skills[] or commands[] changed, verify: (1) every referenced skill exists at skills/<name>/SKILL.md. (2) skills/onboarding/SKILL.md Step 3 and Step 5 still match. (3) README.md 'What's Inside' table still matches. (4) scripts/install.sh still works for the new skill set."
+    emit "plugin.json was modified. If skills[] changed, verify: (1) every referenced skill directory contains a SKILL.md. (2) skills/onboarding/SKILL.md Step 3 and Step 5 still match. (3) README.md 'What's Inside' table still matches. (4) scripts/install.sh still works for the new skill set."
     ;;
   CLAUDE.md)
     emit "Project CLAUDE.md was modified. If 'Adding a New Skill' steps or 'Skill Authoring Rules' changed, verify: (1) README.md reflects the same conventions. (2) docs/superpowers/specs/2026-04-16-onboarding-agent-design.md is still consistent."
@@ -38,7 +38,7 @@ case "$REL" in
     emit "A design spec was modified. If decisions changed, verify the corresponding plan in docs/superpowers/plans/ and any affected SKILL.md files reflect the new contract."
     ;;
   scripts/install.sh|scripts/uninstall.sh|scripts/install.ps1|scripts/uninstall.ps1)
-    emit "Install/uninstall script was modified. Verify: (1) README.md installation instructions still match. (2) docs/installation.md (if present) still matches. (3) .claude-plugin/plugin.json skills/commands arrays are consistent with what the script installs."
+    emit "Install/uninstall script was modified. Verify: (1) README.md installation instructions still match. (2) docs/installation.md (if present) still matches. (3) .claude-plugin/plugin.json skills[] is consistent with what the script installs."
     ;;
 esac
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,7 @@
 ### New skill
 - [ ] `skills/[name]/SKILL.md` created following existing skill pattern
 - [ ] Skill directory added to `skills[]` in `.claude-plugin/plugin.json` (the slash command name derives from the directory name)
+- [ ] Trigger-eval fixture added at `evals/[name].json` (>=5 should-trigger, >=3 should-not-trigger prompts)
 - [ ] New skill added as option in `skills/onboarding/SKILL.md` (Step 3 and Step 5)
 - [ ] Row added to "What's Inside" table in `README.md`
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,8 +10,7 @@
 
 ### New skill
 - [ ] `skills/[name]/SKILL.md` created following existing skill pattern
-- [ ] Skill path added to `skills[]` in `.claude-plugin/plugin.json`
-- [ ] Slash command added to `commands[]` in `.claude-plugin/plugin.json`
+- [ ] Skill directory added to `skills[]` in `.claude-plugin/plugin.json` (the slash command name derives from the directory name)
 - [ ] New skill added as option in `skills/onboarding/SKILL.md` (Step 3 and Step 5)
 - [ ] Row added to "What's Inside" table in `README.md`
 

--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -1,0 +1,43 @@
+name: Skill trigger evals
+
+# Measures skill routing accuracy against the fixtures in evals/.
+# Not run on every PR (each full run judges ~160 prompts and costs tokens);
+# fixture presence and validity are enforced for free by consistency.yml.
+# Spec: docs/superpowers/specs/2026-06-12-skill-eval-harness-design.md
+
+on:
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "Judge model (alias like haiku/sonnet or a full model ID)"
+        required: false
+        default: "haiku"
+  schedule:
+    - cron: "23 5 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  trigger-evals:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run skill trigger evals
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          scripts/run-skill-evals.sh \
+            --model "${{ github.event.inputs.model || 'haiku' }}" \
+            --jobs 4 \
+            --report eval-report.json
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: skill-eval-report
+          path: eval-report.json
+          if-no-files-found: ignore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,9 @@ A Claude Code plugin with 16 skills (onboarding, setup skills, and maintenance u
 1. Create `skills/[skill-name]/SKILL.md`
 2. Follow the pattern from existing skills: language detection, handoff context consumption, installation method question, 3–7 context questions (one at a time), artifact generation, completion summary
 3. Add the skill directory (e.g. `skills/[skill-name]`) to `skills[]` in `.claude-plugin/plugin.json` — the slash command name derives from the directory name
-4. Add the new path as an option in `skills/onboarding/SKILL.md` (Step 3 and Step 5)
-5. Update `README.md` (What's Inside table)
+4. Add a trigger-eval fixture at `evals/[skill-name].json` (>=5 should-trigger, >=3 should-not-trigger prompts; see `docs/superpowers/specs/2026-06-12-skill-eval-harness-design.md`)
+5. Add the new path as an option in `skills/onboarding/SKILL.md` (Step 3 and Step 5)
+6. Update `README.md` (What's Inside table)
 
 ## Repository Language Rule
 All public repo artifacts — GitHub issues, PR titles/descriptions, commit messages, code comments, docs — must be written in English, regardless of the conversation language. Conversation with the user may be in German; output that lands in the repo or on GitHub must not.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,12 +10,12 @@ A Claude Code plugin with 16 skills (onboarding, setup skills, and maintenance u
 - `docs/superpowers/specs/` — design documents
 - `docs/superpowers/plans/` — implementation plans
 
-**Command registry source of truth:** slash commands are defined in `.claude-plugin/plugin.json` under `commands[]`. This repository currently does not use project-local `.claude/commands/` entrypoints.
+**Command registry source of truth:** slash commands derive from skill directory names — `skills/<name>/` exposes `/<name>`, and the command description comes from the skill's SKILL.md frontmatter `description`. The manifest registers skill directories in `skills[]`; the current plugin schema has no `commands[]` field, and this repository does not use project-local `.claude/commands/` entrypoints.
 
 ## Adding a New Skill
 1. Create `skills/[skill-name]/SKILL.md`
 2. Follow the pattern from existing skills: language detection, handoff context consumption, installation method question, 3–7 context questions (one at a time), artifact generation, completion summary
-3. Add the skill path to `skills[]` and the slash command to `commands[]` in `.claude-plugin/plugin.json`
+3. Add the skill directory (e.g. `skills/[skill-name]`) to `skills[]` in `.claude-plugin/plugin.json` — the slash command name derives from the directory name
 4. Add the new path as an option in `skills/onboarding/SKILL.md` (Step 3 and Step 5)
 5. Update `README.md` (What's Inside table)
 
@@ -32,7 +32,7 @@ All public repo artifacts — GitHub issues, PR titles/descriptions, commit mess
 
 ## Subagent Authoring Rules
 
-The plugin ships its own read-only subagents under `.claude/agents/<name>.md`. They are discovered by Claude Code convention — do NOT register them in `.claude-plugin/plugin.json`. Current catalog: `repo-scanner`, `upgrade-planner`. Adding a new subagent requires a spec update.
+The plugin ships its own read-only subagents under `.claude/agents/<name>.md`. They are discovered by Claude Code convention — do NOT register them in `.claude-plugin/plugin.json`. Current catalog: `repo-scanner`, `upgrade-planner`, `audit-collector`, `artifact-verifier`. Adding a new subagent requires a spec update.
 
 ### File format
 
@@ -43,7 +43,7 @@ Each subagent has YAML frontmatter and a Markdown body:
 name: <kebab-case-name, matches filename>
 description: <one sentence, include "read-only" if applicable>
 tools: <comma-separated whitelist — required>
-model: opus
+model: <tier>  # pick lowest capable tier: haiku for read-only scans, sonnet for analysis/planning, opus only for complex reasoning; use aliases, not dated model IDs
 ---
 
 # <Human-readable name>
@@ -96,7 +96,7 @@ When a setup skill generates a project-local subagent (`.claude/agents/<slug>.md
 | `component-auditor` | web-development-setup | Read, Grep, Glob |
 | `notebook-auditor` | data-science-setup | Read, Grep, Glob, Bash |
 | `writing-style-auditor` | academic-writing-setup | Read, Grep, Glob |
-| `obsidian-vault-keeper` | knowledge-base-builder | Bash, Read, Glob, Grep |
+| `obsidian-vault-keeper` | knowledge-base-setup | Bash, Read, Glob, Grep |
 
 **Topic exclusivity:** Each slug has exactly one owning skill. Two skills never write the same filename. Adding a new subagent requires a spec update, not an ad-hoc skill change.
 
@@ -180,13 +180,14 @@ When a setup skill produces rule-like content for the user's project, apply this
 |---|---|---|
 | `writing-style.md` | academic-writing-setup | Voice, tense, section rules |
 | `citation-rules.md` | academic-writing-setup | `.bib` conventions, no-invented-citations |
-| `obsidian-cli.md` | knowledge-base-builder | CLI command reference (read-on-demand) |
+| `obsidian-cli.md` | knowledge-base-setup | CLI command reference (read-on-demand) |
 | `data-schema.md` | data-science-setup | Datasets, columns, lineage |
 | `evaluation-protocol.md` | data-science-setup | Metrics, splits, baselines |
 | `api-conventions.md` | web-development-setup | Route layout, error shape, auth |
 | `component-structure.md` | web-development-setup | Atomic/container split, colocation |
 | `env-vars.md` | web-development-setup | Public-prefix rules, secret stores |
 | `infra-safety.md` | devops-setup | Pre-apply pause rules |
+| `content-voice-<platform>.md` | content-voice-setup | Per-platform voice rules |
 
 **Topic exclusivity:** Each whitelist filename has exactly one owning skill. No two skills ever write the same filename. Adding a new topic or owner requires a spec update, not an ad-hoc skill change.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ New setup skills are the most valuable contribution. Each skill covers a use cas
    - 3–7 context questions, asked one at a time
    - Artifact generation (at minimum: a tailored CLAUDE.md and .gitignore)
    - Completion summary listing everything created and any skipped items
-4. **Update the plugin manifest:** add the skill path to `skills[]` and the slash command to `commands[]` in `.claude-plugin/plugin.json`
+4. **Update the plugin manifest:** add the skill directory (e.g. `skills/[name]`) to `skills[]` in `.claude-plugin/plugin.json` — the slash command name derives from the directory name, its description from the SKILL.md frontmatter
 5. **Update the orchestrator:** add your skill as a numbered option in `skills/onboarding/SKILL.md` (Step 3 and the dispatch table in Step 5)
 6. **Update README.md:** add a row to the "What's Inside" table
 7. **Open a pull request** with a description of the use case your skill serves and an example of the CLAUDE.md it generates

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,9 +19,10 @@ New setup skills are the most valuable contribution. Each skill covers a use cas
    - Artifact generation (at minimum: a tailored CLAUDE.md and .gitignore)
    - Completion summary listing everything created and any skipped items
 4. **Update the plugin manifest:** add the skill directory (e.g. `skills/[name]`) to `skills[]` in `.claude-plugin/plugin.json` — the slash command name derives from the directory name, its description from the SKILL.md frontmatter
-5. **Update the orchestrator:** add your skill as a numbered option in `skills/onboarding/SKILL.md` (Step 3 and the dispatch table in Step 5)
-6. **Update README.md:** add a row to the "What's Inside" table
-7. **Open a pull request** with a description of the use case your skill serves and an example of the CLAUDE.md it generates
+5. **Add a trigger-eval fixture:** create `evals/[name].json` with at least 5 should-trigger and 3 should-not-trigger prompts (see `docs/superpowers/specs/2026-06-12-skill-eval-harness-design.md`), then run `scripts/run-skill-evals.sh --skill [name]`
+6. **Update the orchestrator:** add your skill as a numbered option in `skills/onboarding/SKILL.md` (Step 3 and the dispatch table in Step 5)
+7. **Update README.md:** add a row to the "What's Inside" table
+8. **Open a pull request** with a description of the use case your skill serves and an example of the CLAUDE.md it generates
 
 ## Improving Existing Skills
 

--- a/README.md
+++ b/README.md
@@ -45,15 +45,16 @@ Not sure where to start? Run `/onboarding` and we'll figure it out with you. Or 
 
 ## Install
 
-### Option 1 — Plugin marketplace (recommended, soon)
+### Option 1 — Plugin marketplace (recommended)
+
+This repo ships a self-hosted `marketplace.json`, so the standard plugin marketplace flow works directly:
 
 ```
-/plugin install claude-onboarding-agent
+/plugin marketplace add a2ngerer/claude_onboarding_agent
+/plugin install claude-onboarding-agent@claude-onboarding-agent
 ```
 
-> Marketplace listing is in progress. Use Option 2 in the meantime.
-
-### Option 2 — One-liner (works today)
+### Option 2 — One-liner
 
 **macOS / Linux**
 
@@ -124,7 +125,7 @@ Suggest the most likely use case (or ask if the repo is empty)
      ├── 1. Coding Setup
      ├── 2. Web Development
      ├── 3. Data Science / ML
-     ├── 4. Knowledge Base Builder
+     ├── 4. Knowledge Base Setup
      ├── 5. Office & Business
      ├── 6. Research & Writing
      ├── 7. Academic Writing
@@ -163,11 +164,11 @@ Every setup skill creates a tailored `CLAUDE.md` with context and instructions s
 | Content | ✓ + brand voice | — | — | ✓ media files | — | Superpowers (optional) |
 | DevOps | ✓ + infra workflow | ✓ 3 roles | ✓ stack permissions | ✓ IaC state, secrets | ✓ plan-before-apply guard (opt-in) | Superpowers (optional) |
 | Design | ✓ + UI guidelines | ✓ 2 roles | ✓ stack permissions | ✓ design assets | — | Superpowers (optional) + opt-in Figma MCP |
-| Graphify | ✓ + delimited pointer block (`/graphify query / path / explain`) | — | Graphify registers its own PreToolUse hook via `graphify install` | — | (Graphify's own PreToolUse hook) | `graphifyy` (Python package via `uv tool install`, `pipx` fallback) |
+| Graphify | ✓ + delimited pointer block (`/graphify query / path / explain`) | — | Graphify registers its own PreToolUse hook via `graphify install` | — | (Graphify's own PreToolUse hook) | `graphifyy` (Python package via `uv tool install`, `pipx` fallback — note: the PyPI package name is `graphifyy` with a double y; the CLI command and the [GitHub repo](https://github.com/safishamsi/graphify) use `graphify` with a single y) |
 
 ### The coding workflow (powered by Superpowers)
 
-The Coding Setup installs [Superpowers](https://github.com/obra/superpowers) — a battle-tested Claude Code workflow library with 94,000+ users — and wires it into your `CLAUDE.md`. Every future session follows a proven loop:
+The Coding Setup installs [Superpowers](https://github.com/obra/superpowers) — a widely used, battle-tested Claude Code workflow library — and wires it into your `CLAUDE.md`. Every future session follows a proven loop:
 
 ```
 Brainstorm idea → Write plan → Dispatch subagents → Code review → Commit
@@ -175,7 +176,7 @@ Brainstorm idea → Write plan → Dispatch subagents → Code review → Commit
 
 ### The knowledge base (Karpathy pattern)
 
-The Knowledge Base Builder sets up the [Karpathy LLM Wiki pattern](https://github.com/forrestchang/andrej-karpathy-skills): a `raw/` folder for source material and a `wiki/` folder of interlinked markdown notes that Claude builds and maintains. Drop files into `raw/`, ask Claude to ingest them — the wiki grows automatically.
+The Knowledge Base Setup sets up the [Karpathy LLM Wiki pattern](https://github.com/forrestchang/andrej-karpathy-skills): a `raw/` folder for source material and a `wiki/` folder of interlinked markdown notes that Claude builds and maintains. Drop files into `raw/`, ask Claude to ingest them — the wiki grows automatically.
 
 Optional: connect [Obsidian](https://obsidian.md) via the official Obsidian CLI, wired into a dedicated `obsidian-vault-keeper` subagent. Vault reads/writes only load the CLI reference when actually invoked, so chats that don't touch the vault pay zero Obsidian tokens — unlike a persistent MCP whose tool schemas are loaded into every session.
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,19 @@ Skills fetch anchors at runtime from a pinned `raw.githubusercontent.com` URL vi
 
 ---
 
+## Skill trigger evals
+
+Skill routing depends entirely on each skill's frontmatter description. To catch silent routing regressions, every skill ships a trigger-eval fixture under [`evals/`](evals/) — realistic should-trigger and should-not-trigger prompts. The runner asks a judge model to route each prompt against the live catalog and reports per-skill pass rates:
+
+```
+scripts/run-skill-evals.sh                      # full suite (claude CLI or ANTHROPIC_API_KEY)
+scripts/run-skill-evals.sh --skill coding-setup # one suite, e.g. after a description change
+```
+
+CI runs the full suite weekly (`skill-evals.yml`); fixture presence and validity are enforced on every PR. Design: [`docs/superpowers/specs/2026-06-12-skill-eval-harness-design.md`](docs/superpowers/specs/2026-06-12-skill-eval-harness-design.md).
+
+---
+
 ## Language support
 
 All skills detect your language automatically from your first message and respond accordingly. Supported: English, German, Spanish, French, and any other language Claude Code supports.

--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -1,5 +1,19 @@
 # Release Notes
 
+## v1.1.0 — 2026-06-12
+
+June 2026 state-of-the-art refresh.
+
+- Anchors updated to the current Claude model lineup (Fable 5, Opus 4.8)
+- Concrete MCP install commands in setup skills
+- Consistency fixes across the maintenance chain: `/tipps` phantom references removed, `knowledge-base-builder` rename to `knowledge-base-setup` completed, `web-development` slug recognized by `upgrade-setup`
+- Plugin manifest migrated to the current schema: `skills[]` now lists skill directories (`./skills/<name>`), the legacy `commands[]` field is removed (slash commands derive from skill directory names), `displayName` added; `claude plugin validate` passes
+- Portable dependency hook: repo root derived from `CLAUDE_PROJECT_DIR`/git instead of a hardcoded absolute path; dead `installation.md` case pattern fixed
+- Subagent model tiering: haiku for lightweight read-only agents, sonnet for mid-tier tasks — opus no longer used everywhere
+- Self-hosted plugin marketplace: `marketplace.json` added; `/plugin marketplace add a2ngerer/claude_onboarding_agent` now works
+- Modernized stack defaults in setup skills: Create React App dropped in favor of Vite/Next.js, Python minimum bumped to 3.12, pre-commit revisions unpinned
+- Removed frozen install-count claims from documentation
+
 ## v1.0.1 — 2026-04-24
 
 Documentation and maintenance update.

--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -1,5 +1,16 @@
 # Release Notes
 
+## v1.2.0 — 2026-06-12
+
+Skill trigger eval harness.
+
+- Trigger-eval fixtures for all 16 skills under `evals/` (should-trigger and should-not-trigger prompts, including non-English samples)
+- `scripts/run-skill-evals.sh`: judges every prompt against the live skill catalog (Anthropic API or local `claude` CLI in safe mode), per-skill pass rates, failure listing, JSON report, threshold gate
+- `.github/workflows/skill-evals.yml`: weekly + on-demand eval runs (requires the `ANTHROPIC_API_KEY` secret)
+- `scripts/check-consistency.sh` now enforces fixture presence, validity, and minimum prompt counts on every PR
+- New-skill checklists (CLAUDE.md, CONTRIBUTING, PR template) require a fixture; the dependents hook reminds about fixtures on SKILL.md edits
+- Design: `docs/superpowers/specs/2026-06-12-skill-eval-harness-design.md`
+
 ## v1.1.0 — 2026-06-12
 
 June 2026 state-of-the-art refresh.

--- a/docs/anchors/claude-models.md
+++ b/docs/anchors/claude-models.md
@@ -1,29 +1,47 @@
 ---
 name: claude-models
 description: Current Claude model IDs, aliases, context limits, and recommended defaults
-last_updated: 2026-04-21
+last_updated: 2026-06-12
 sources:
   - https://docs.claude.com/en/docs/about-claude/models
   - https://docs.claude.com/en/docs/about-claude/pricing
-version: 1
+version: 2
 ---
 
 ## Latest family
 
-Claude 4.x is the current family as of `last_updated`. Default to the latest IDs listed below unless a project has pinned an older version for a specific reason.
+Claude 4.x / 5.x is the current family as of `last_updated`. The Fable 5 tier sits above Opus as the highest-capability generally available model. Default to the latest IDs listed below unless a project has pinned an older version for a specific reason.
 
 ## Model IDs
 
-| Tier   | Model ID              | Alias              | Context | Typical use case |
-|--------|-----------------------|--------------------|---------|------------------|
-| Opus   | `claude-opus-4-7`     | claude-opus-latest | 200k    | Hardest reasoning, deep code analysis, agentic workflows |
-| Sonnet | `claude-sonnet-4-6`   | claude-sonnet-latest | 200k  | Balanced default — most coding and general tasks |
-| Haiku  | `claude-haiku-4-5-20251001` | claude-haiku-latest | 200k | Fast, cheap, high-volume tasks and subagents |
+| Tier   | Model ID              | Alias   | Context | Max output | Input / Output (per MTok) | Typical use case |
+|--------|-----------------------|---------|---------|------------|---------------------------|------------------|
+| Fable  | `claude-fable-5`      | `fable` | 1M      | 128k       | $10 / $50                 | Maximum capability, Mythos-class reasoning, adaptive thinking |
+| Opus   | `claude-opus-4-8`     | `opus`  | 1M      | 128k       | $5 / $25                  | Hard reasoning, deep code analysis, agentic workflows; defaults to high effort |
+| Sonnet | `claude-sonnet-4-6`   | `sonnet`| 1M      | 64k        | $3 / $15                  | Balanced default — most coding and general tasks |
+| Haiku  | `claude-haiku-4-5-20251001` | `haiku` | 200k | 64k    | $1 / $5                   | Fast, cheap, high-volume tasks and subagents |
 
-## Deprecated
+`claude-mythos-5` is the same model as Fable 5 but without dual-use safety measures. It is invitation-only and not recommended for general use.
 
-Do not use these IDs in new code or configs. They will stop working on their retirement date and generally point to weaker models than the current family.
+## Aliases
 
+The `model:` field accepts short aliases (`fable`, `opus`, `sonnet`, `haiku`) plus `inherit` (take the parent agent's model). Aliases always point to the current recommended snapshot for that tier — they move when Anthropic promotes a new default.
+
+## ID pinning behavior
+
+Since the 4.6 generation, undated model IDs (e.g. `claude-opus-4-8`) are pinned snapshots, not moving pointers. Use them when you want stability without memorizing a full dated ID. Aliases still move; if you want reproducibility across alias promotions, use the undated or dated ID directly.
+
+## Deprecated / retiring soon
+
+Do not use these IDs in new code or configs. Entries marked with a retirement date will stop working on that date.
+
+- `claude-sonnet-4-0` — **retires 2026-06-15 (imminent)**
+- `claude-opus-4-0` — **retires 2026-06-15 (imminent)**
+- `claude-opus-4-1` — retires 2026-08-05
+- `claude-opus-4-7` — legacy, still available
+- `claude-opus-4-6` — legacy, still available
+- `claude-opus-4-5` — legacy, still available
+- `claude-sonnet-4-5` — legacy, still available
 - `claude-3-opus-20240229`
 - `claude-3-sonnet-20240229`
 - `claude-3-haiku-20240307`
@@ -34,14 +52,18 @@ Do not use these IDs in new code or configs. They will stop working on their ret
 - `claude-2.0`
 - `claude-instant-1.2`
 
+## Tokenizer note
+
+Fable 5, Mythos 5, and Opus 4.7+ use a new tokenizer that produces roughly 30% more tokens for the same text. Factor this into cost estimates when migrating from older models.
+
 ## Defaults
 
-- **General coding (Claude Code default):** `claude-sonnet-4-6`
-- **Deep reasoning / agentic planning:** `claude-opus-4-7`
-- **High-throughput subagents / background tasks:** `claude-haiku-4-5-20251001`
-- **Building AI apps on the Anthropic SDK:** start with `claude-sonnet-4-6`; upgrade to Opus only when quality demands it.
+- **Everyday tasks and agentic coding (Claude Code default):** `claude-sonnet-4-6`
+- **Deep reasoning / agentic planning:** `claude-opus-4-8`
+- **Maximum capability:** `claude-fable-5`
+- **Fast / cheap subagent scans:** `claude-haiku-4-5-20251001`
 
 ## Tips
 
-- Prefer the **dated ID** (`claude-sonnet-4-6`) over an alias in production — aliases move silently.
-- When migrating between versions, re-run your eval suite; prompts tuned for one model family may need light adjustment.
+- Use undated IDs (`claude-opus-4-8`) for production stability; they are pinned snapshots since the 4.6 generation. Aliases (`opus`, `sonnet`, etc.) move when defaults are promoted.
+- When migrating between models, re-run your eval suite; prompts tuned for one model family may need light adjustment.

--- a/docs/anchors/claude-tools.md
+++ b/docs/anchors/claude-tools.md
@@ -1,14 +1,14 @@
 ---
 name: claude-tools
 description: How to configure Claude's core tooling surface — hooks, rules, memory files, settings, slash commands, plugins
-last_updated: 2026-04-21
+last_updated: 2026-06-12
 sources:
   - https://docs.claude.com/en/docs/claude-code/hooks
   - https://docs.claude.com/en/docs/claude-code/settings
   - https://docs.claude.com/en/docs/claude-code/plugins
   - https://docs.claude.com/en/docs/claude-code/slash-commands
   - https://docs.claude.com/en/docs/claude-code/memory
-version: 1
+version: 2
 ---
 
 ## Memory files
@@ -22,20 +22,33 @@ version: 1
 
 ## Settings
 
-Top-level keys in `.claude/settings.json`: `permissions`, `env`, `hooks`, `mcpServers`, `model`, `agent`, `outputStyle`, `sandbox`, `claudeMdExcludes`. Permission rules evaluate in order `deny → ask → allow`; first match wins.
+Top-level keys in `.claude/settings.json`: `permissions`, `env`, `hooks`, `mcpServers`, `model`, `agent`, `outputStyle`, `sandbox`, `claudeMdExcludes`, `fallbackModel`, `requiredMinimumVersion`, `enforceAvailableModels`. Permission rules evaluate in order `deny → ask → allow`; first match wins.
 
 ```json
 { "permissions": { "allow": ["Bash(npm run test *)"], "deny": ["Read(./.env)"] } }
 ```
+
+- **`fallbackModel`** — model to use when the primary `model` is unavailable or rate-limited.
+- **`requiredMinimumVersion`** — semver string; Claude Code refuses to run if the installed version is older.
+- **`enforceAvailableModels`** — boolean; when `true`, rejects model IDs not available in the current account/tier at startup rather than failing at runtime.
+
+**Safe mode:** Set `CLAUDE_CODE_SAFE_MODE=1` in the environment to disable CLAUDE.md loading, plugins, skills, hooks, and MCP servers. Useful for security-sensitive CI environments or troubleshooting a broken config.
 
 ## Hooks
 
 | Event | Typical use | Example |
 |---|---|---|
 | `SessionStart` | Load context or env vars on session open | Inject current git branch |
+| `InstructionsLoaded` | React to what triggered loading (new session, `/reload-skills`, plugin install); inspect `load_reason` | Log which skills were loaded |
 | `UserPromptSubmit` | Validate or enrich the user prompt | Block secret patterns |
 | `PreToolUse` | Block or gate a tool call | Deny `Bash(rm -rf *)` |
 | `PostToolUse` | Lint or log after a tool runs | Auto-run `eslint --fix` after `Edit` |
+| `PostToolBatch` | React after a full parallel tool batch completes | Summarize a batch of file reads |
+| `MessageDisplay` | Intercept or annotate a message before it is shown | Inject a reminder banner |
+| `PreCompact` | Save state before context compaction | Checkpoint session notes |
+| `PostCompact` | Re-inject context after compaction | Reload pinned snippets |
+| `WorktreeCreate` | Set up a fresh worktree (install deps, copy env) | `npm ci` in the new branch |
+| `WorktreeRemove` | Clean up after a worktree is deleted | Remove temp build artifacts |
 | `Stop` | Cleanup when Claude finishes a turn | Persist session notes |
 | `SessionEnd` | Release resources or save artifacts | Flush metrics |
 
@@ -47,10 +60,32 @@ Hooks live in `.claude/settings.json` under `hooks.<EventName>[]` with a `matche
 - Plugin-provided skills are namespaced: `/<plugin-name>:<skill-name>` to prevent collisions.
 - Arguments: `$ARGUMENTS` (full string), `$0`/`$1`/… or `$ARGUMENTS[N]` (positional), named args via `arguments:` frontmatter.
 - Name slugs: lowercase letters, digits, hyphens only; max 64 chars.
+- `/reload-skills` — hot-reload skill/command files without restarting the session.
+- `/cd <path>` — change the working directory for the current session.
+- `/plugin list` — list installed plugins and their status.
+- `claude plugin init` — scaffold a new plugin in the current directory (CLI, not a slash command).
+- `claude agents` — list all available named subagents (CLI).
+
+## SKILL.md frontmatter fields
+
+| Field | Purpose |
+|---|---|
+| `argument-hint` | Short placeholder shown in autocomplete (e.g. `[branch]`) |
+| `allowed-tools` | Comma-separated tool whitelist for this skill's invocation |
+| `model` | Override model for this skill (accepts aliases: `fable`, `opus`, `sonnet`, `haiku`, `inherit`) |
+| `effort` | `low` / `normal` / `high` — hint to the model's thinking budget |
+| `context: fork` | Run the skill in a forked context (isolated from main conversation) |
+| `context: agent` | Run the skill as a full subagent turn |
+| `paths` | Glob list — load this skill only when CWD matches |
+| `disable-model-invocation` | `true` — skill runs its command without calling the model (pure automation) |
+| `user-invocable` | `false` — hides the skill from `/` autocomplete; only callable programmatically |
 
 ## Plugins
 
-- Manifest: `.claude-plugin/plugin.json` with `name`, `version` (semver), `description`, optional `author`, `homepage`, `repository`.
+- Manifest: `.claude-plugin/plugin.json` with `name`, `version` (semver), `description`, optional `author`, `homepage`, `repository`, `displayName`, `defaultEnabled`, `dependencies`.
+  - `displayName` — human-readable name shown in the marketplace and `/plugin list`.
+  - `defaultEnabled` — boolean; whether the plugin activates on install without user opt-in.
+  - `dependencies` — list of other plugin names that must be installed for this plugin to function.
 - Components sit at the plugin root, not inside `.claude-plugin/`: `skills/`, `agents/`, `commands/`, `hooks/`, `.mcp.json`, `.lsp.json`, `monitors/`, `settings.json`.
 - Version every release; users update through the marketplace. `/reload-plugins` picks up local edits.
 

--- a/docs/anchors/mcp-servers.md
+++ b/docs/anchors/mcp-servers.md
@@ -1,12 +1,12 @@
 ---
 name: mcp-servers
 description: Recommended MCP servers by use case for Claude Code
-last_updated: 2026-04-21
+last_updated: 2026-06-12
 sources:
   - https://docs.claude.com/en/docs/claude-code/mcp
   - https://github.com/modelcontextprotocol/servers
   - https://www.anthropic.com/engineering
-version: 2
+version: 3
 ---
 
 ## Recommended
@@ -26,26 +26,41 @@ Per-category details follow. Keep the set small: every installed MCP expands the
 
 - **filesystem** — scoped filesystem access beyond the working directory. Install: `claude mcp add filesystem npx -- -y @modelcontextprotocol/server-filesystem <path>`
 - **git** — read git history, blame, diffs without shelling out. Install: `claude mcp add git uvx -- mcp-server-git`
-- **github** — issues, PRs, reviews via the GitHub API. Install: `claude mcp add github npx -- -y @modelcontextprotocol/server-github` (needs `GITHUB_PERSONAL_ACCESS_TOKEN`)
+- **github** — issues, PRs, reviews via the official GitHub MCP server. `@modelcontextprotocol/server-github` has been archived; use the official `github/github-mcp-server` instead.
+  - Remote (recommended): `claude mcp add-json github '{"type":"http","url":"https://api.githubcopilot.com/mcp","headers":{"Authorization":"Bearer YOUR_GITHUB_PAT"}}'`
+  - Local via Docker: `claude mcp add github -e GITHUB_PERSONAL_ACCESS_TOKEN=YOUR_PAT -- docker run -i --rm -e GITHUB_PERSONAL_ACCESS_TOKEN ghcr.io/github/github-mcp-server`
 
 ## Knowledge base
 
-- **obsidian (official CLI + subagent)** — use the official Obsidian CLI plus the `obsidian-vault-keeper` subagent pattern. The older third-party Obsidian MCP has known correctness issues; prefer this path. See `skills/knowledge-base-builder/SKILL.md`.
+- **obsidian (official CLI + subagent)** — use the official Obsidian CLI plus the `obsidian-vault-keeper` subagent pattern. The older third-party Obsidian MCP has known correctness issues; prefer this path. See `skills/knowledge-base-setup/SKILL.md`.
 
 ## Design
 
-- **figma-context** — read Figma frames into context for UI work. Install: see https://github.com/GLips/Figma-Context-MCP
+- **figma-context** — read Figma frames into context for UI work. Uses the `figma-developer-mcp` npm package (GLips/Figma-Context-MCP).
+  Install: `claude mcp add -s user figma-mcp -- npx -y figma-developer-mcp --figma-api-key=YOUR_FIGMA_API_KEY --stdio`
+  Alternatively set `FIGMA_API_KEY` in the environment and omit the flag. API key from: https://www.figma.com/developers/api#access-tokens
 
 ## Productivity
 
 - **slack** — read channels, post messages. Install: `claude mcp add slack npx -- -y @modelcontextprotocol/server-slack`
 - **linear** — issues and projects. Install via Linear's official MCP integration.
-- **gmail / calendar** — via official Google MCP integrations where available; otherwise the community `gmail-mcp-server`.
+- **gmail / calendar / drive** — Google hosts official remote MCP endpoints for these services. Authentication requires OAuth2 via a Google Cloud project and is configured through the Claude.ai/Claude Desktop GUI (Settings > Connectors), not via a single CLI command. For Claude Code headless use, the Google Workspace CLI is the practical alternative:
+  ```
+  npm install -g @googleworkspace/cli
+  gws auth setup
+  claude mcp add gws -- gws mcp -s drive,gmail,calendar
+  ```
+  The remote endpoints (`gmailmcp.googleapis.com`, `calendarmcp.googleapis.com`, `drivemcp.googleapis.com`) require a paid Claude plan and OAuth2 bearer tokens that cannot be injected as a static header — use the GUI connector flow for those.
 
 ## DevOps / cloud
 
 - **kubernetes** — cluster read access, kubectl-equivalent queries. Community servers available; pin a version before production use.
 - **aws / gcp** — prefer official CLIs wrapped via allowed Bash permissions; MCP wrappers exist but are less mature.
+
+## Transport note
+
+- **Prefer HTTP for remote servers, stdio for local servers.** SSE (Server-Sent Events) transport is deprecated and may be removed in a future release.
+- Use `claude mcp add-json` for HTTP servers with complex headers; use `claude mcp add` for stdio servers.
 
 ## Selection tips
 

--- a/docs/anchors/subagents.md
+++ b/docs/anchors/subagents.md
@@ -1,13 +1,37 @@
 ---
 name: subagents
 description: Subagent orchestration patterns for Claude Code — when to delegate, how to structure, and what to avoid
-last_updated: 2026-04-21
+last_updated: 2026-06-12
 sources:
   - https://docs.claude.com/en/docs/claude-code/sub-agents
   - https://www.anthropic.com/engineering/multi-agent-research-system
   - https://www.anthropic.com/engineering/claude-code-best-practices
-version: 1
+version: 2
 ---
+
+## Named subagent frontmatter fields
+
+Named subagents live at `.claude/agents/<name>.md` with YAML frontmatter. Available fields:
+
+| Field | Purpose |
+|---|---|
+| `model` | Model to run this agent on. Accepts aliases (`fable`, `opus`, `sonnet`, `haiku`) or full IDs. Defaults to `inherit` (uses the invoking context's model). |
+| `disallowedTools` | Comma-separated list of tools the subagent cannot call, even if its `tools:` whitelist includes them. |
+| `maxTurns` | Maximum number of agentic turns before the subagent is forced to return. Prevents runaway loops. |
+| `skills` | Comma-separated skill slugs to preload into the subagent's context. |
+| `memory` | `true` / `false` — whether the subagent has access to the user's memory files. Default: `false` for read-only agents. |
+| `effort` | `low` / `normal` / `high` — thinking budget hint passed to the model. |
+| `isolation` | `worktree` — run the subagent in a temporary git worktree; branch and path returned to the caller on exit. |
+| `background` | `true` — spawn the subagent in the background; caller is notified on completion rather than waiting. |
+
+## Model tiering for subagents
+
+- **Haiku** (`haiku`) — read-only scans, grep/glob searches, file counts, cheap classification. Fastest and cheapest.
+- **Sonnet** (`sonnet`) — default worker for most implementation, review, and analysis tasks. Good balance of cost and capability.
+- **Opus** (`opus`) — complex multi-step reasoning, architectural decisions, tasks that must get it right the first time.
+- **Fable** (`fable`) — maximum capability; reserve for the hardest reasoning tasks where cost is secondary to quality.
+
+Set `model: haiku` on read-only scanner agents; let implementation agents default to `sonnet` via `inherit`. Bump to `opus` or `fable` only when the task demonstrably needs it.
 
 ## When to use a subagent
 
@@ -58,7 +82,7 @@ The main agent waits once, then relays a consolidated summary — it does not na
 
 ## Anti-patterns
 
-- Subagents dispatching other subagents without bounds — nested fan-out blows up context and latency.
+- Subagents dispatching other subagents — nesting is technically supported up to 5 levels (since v2.1.172) but remains strongly discouraged; nested fan-out multiplies context cost and latency unpredictably.
 - The main agent narrating subagent work step-by-step instead of relaying the final summary.
 - Dispatching a subagent for a task that is one tool call — the overhead dwarfs the work.
 - Vague prompts like "research X" with no output format — produces redundant searches and unfocused summaries.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,7 +23,7 @@ The one-liner fetches `install.sh` (macOS / Linux) or `install.ps1` (Windows) an
 
 **Why junctions on Windows:** the PowerShell script uses directory junctions instead of symbolic links. Junctions work without admin rights and without Developer Mode, while `SymbolicLink` requires one of the two. For Claude Code's read-only skill discovery, the two are equivalent.
 
-The `plugin.json` manifest at `.claude-plugin/plugin.json` declares which skill folders and which slash-command names belong to the plugin. Claude Code doesn't consume this file yet — today it only matters for the future plugin system.
+The `plugin.json` manifest at `.claude-plugin/plugin.json` declares which skill folders and which slash-command names belong to the plugin. The accompanying `marketplace.json` at `.claude-plugin/marketplace.json` enables the self-hosted plugin marketplace flow (see Option 2 below).
 
 **Update:** re-run the same curl command. The script detects an existing clone and does `git pull` instead of re-cloning.
 
@@ -39,29 +39,28 @@ The `plugin.json` manifest at `.claude-plugin/plugin.json` declares which skill 
 
 ---
 
-## Future Method: Claude Plugin Marketplace
+## Option 2: Self-Hosted Plugin Marketplace
 
-Anthropic is building a first-class plugin system for Claude Code. When it ships, installation will be a single command:
+This repo ships a `.claude-plugin/marketplace.json` that makes it discoverable via the Claude Code plugin marketplace commands. Once the repo is registered as a marketplace source, installation is:
 
 ```
-/plugin install claude-onboarding-agent
+/plugin marketplace add a2ngerer/claude_onboarding_agent
+/plugin install claude-onboarding-agent@claude-onboarding-agent
 ```
 
-Under the hood, Claude Code will:
+Under the hood, Claude Code:
 
-1. Look up the plugin in a central registry (similar to npm or Homebrew)
-2. Download and verify the plugin archive
-3. Register skills, commands, permissions, and MCP integrations declared in `plugin.json`
-4. Make all slash-commands available immediately — no shell script, no symlinks, no `~/.claude/skills/` directory required
+1. Fetches the `marketplace.json` from the repo to discover available plugins
+2. Reads the `plugin.json` manifest to find the `skills[]` directory declarations
+3. Registers each skill; the slash-command name derives from the skill directory name
+4. Makes all slash-commands available immediately
 
-The `plugin.json` file in this repo is already structured to be compatible with that future format. The fields `skills[]`, `commands[]`, `author`, `version`, and `homepage` mirror what the plugin registry will expect. When the marketplace launches, this plugin should require little or no changes to be listable.
-
-**Key difference from today:** the current curl approach requires the user's shell to run a bash script with `git` and filesystem access. The plugin system will handle all of that inside Claude Code itself, with sandboxing and signature verification — closer to how browser extensions or VS Code extensions work today.
+The `plugin.json` fields `skills[]`, `author`, `version`, and `homepage` are what the plugin system consumes. The `marketplace.json` adds the discovery layer (owner, plugin listing) that the `/plugin marketplace add` command expects.
 
 | Aspect | Notes |
 |--------|-------|
-| Transparency | Lower — installation runs inside Claude Code, no readable shell script |
-| Security model | Sandboxed — Claude Code verifies signatures, no shell permissions required |
-| Update control | Via Claude Code's own update mechanism — details still open |
+| Transparency | High — both manifest files are readable JSON in the repo |
+| Security model | Depends on Claude Code's plugin verification — no separate shell script needed |
+| Update control | Via Claude Code's own update mechanism |
 | Dependencies | Only Claude Code itself |
-| Recoverability | `/plugin uninstall` — simple, but less transparent than manual deletion |
+| Recoverability | `/plugin uninstall` |

--- a/docs/superpowers/plans/2026-06-12-skill-eval-harness.md
+++ b/docs/superpowers/plans/2026-06-12-skill-eval-harness.md
@@ -1,0 +1,18 @@
+# Skill Trigger Eval Harness — Implementation Plan
+
+Date: 2026-06-12
+Spec: `docs/superpowers/specs/2026-06-12-skill-eval-harness-design.md`
+
+## Steps
+
+1. **Fixtures** — write `evals/<skill>.json` for all 16 skills (6 should-trigger prompts including one German, 4 should-not-trigger near-misses each). Authored in two parallel batches against the full catalog of frontmatter descriptions.
+2. **Runner** — `scripts/run-skill-evals.sh`: catalog extraction from SKILL.md frontmatter, dual backend (Messages API via curl / `claude -p` in safe mode), parallel task execution, per-skill summary table, failure listing, JSON report, threshold gate.
+3. **CI** — `.github/workflows/skill-evals.yml`: workflow_dispatch + weekly cron, uploads the JSON report as an artifact. Requires the `ANTHROPIC_API_KEY` secret.
+4. **Guards** — extend `scripts/check-consistency.sh` (fixture presence, JSON validity, skill-field match, minimum counts) and `.claude/hooks/check-dependencies.sh` (fixture reminder on SKILL.md edits).
+5. **Docs** — README section, CONTRIBUTING new-skill step, PR-template checklist item, CLAUDE.md authoring note.
+6. **Baseline** — run the full suite once, record the baseline pass rate in the PR/commit description, fix any fixture bugs surfaced by the run (fixture bugs, not description rewrites — those are a follow-up).
+7. **Release** — bump plugin.json to 1.2.0, add the RELEASE-NOTES entry, run consistency checks, commit, push.
+
+## Non-goals in this pass
+
+Description rewrites based on eval results. The harness lands first and produces a baseline; description optimization is a separate change with its own review.

--- a/docs/superpowers/specs/2026-06-12-skill-eval-harness-design.md
+++ b/docs/superpowers/specs/2026-06-12-skill-eval-harness-design.md
@@ -1,0 +1,68 @@
+# Skill Trigger Eval Harness — Design
+
+Date: 2026-06-12
+Status: accepted
+Plan: `docs/superpowers/plans/2026-06-12-skill-eval-harness.md`
+
+## Problem
+
+Skill routing in Claude Code is driven entirely by the frontmatter `description:` of each SKILL.md. When a description changes, a new skill with overlapping scope is added, or a model update shifts routing behavior, nothing in this repo detects that `/checkup`-style requests suddenly land in `audit-setup`, or that `research-setup` swallows `academic-writing-setup` traffic. The June 2026 ecosystem audit identified this as the main gap versus the state of the art: `anthropics/skills` measures description trigger rates with should-trigger/should-not-trigger prompt sets, and `wshobson/agents` runs a three-gate PluginEval. This repo has no automated trigger-accuracy signal at all.
+
+## Scope (v1)
+
+- **Description-level trigger evals.** A judge model receives the exact catalog the router sees — skill names plus frontmatter descriptions — and one user message, and picks one skill or `none`.
+- **Out of scope for v1:** full-session end-to-end evals, output-quality judging of generated artifacts, Monte Carlo repetition with confidence intervals, and automatic description optimization. See Future Extensions.
+
+This is an approximation of real routing (the live session model also sees conversation context), but it tests the artifact this repo actually owns: the descriptions.
+
+## Fixtures
+
+- Location: `evals/<skill-name>.json`, one file per skill. Every entry in plugin.json `skills[]` must have one (enforced by `scripts/check-consistency.sh`).
+- The `evals/` directory lives at the repo root and is not shipped to users (`install.sh` links `skills/*/` only).
+
+Schema:
+
+```json
+{
+  "skill": "<skill-name>",
+  "should_trigger": ["<prompt>", "..."],
+  "should_not_trigger": ["<prompt>", "..."]
+}
+```
+
+Authoring rules:
+
+1. `should_trigger`: at least 5 realistic user messages that must route to exactly this skill and could not legitimately route to any other catalog entry. At least one prompt is non-English (skills detect language at runtime; routing must be language-robust).
+2. `should_not_trigger`: at least 3 near-miss prompts from adjacent domains that a sloppy description would wrongly catch — they must route to anything other than this skill (another skill or `none`). Good near-miss types: a neighboring skill's request, a request to USE the domain rather than to SET UP Claude for it, and a generic non-setup question.
+3. No prompt may contain the skill's directory name or slash command — that would test string matching, not the description.
+4. The `skill` field must equal the filename without `.json`.
+
+## Runner
+
+`scripts/run-skill-evals.sh` — bash + jq, no other dependencies.
+
+- Flags: `--skill <name>` (single suite), `--model <alias-or-id>` (default `haiku`), `--threshold <0..1>` (default `0.90`), `--jobs <n>` (default 4), `--report <file>` (JSON report).
+- Backends: the Anthropic Messages API via curl when `ANTHROPIC_API_KEY` is set (CI), otherwise the local `claude` CLI in print mode with `CLAUDE_CODE_SAFE_MODE=1` (clean judging without project context, plugins, or hooks).
+- Judge contract: the model replies with exactly one token — a catalog skill name or `none`. Any unparseable reply is normalized to `none`.
+- Scoring: a `should_trigger` prompt passes iff the predicted skill equals the fixture's skill; a `should_not_trigger` prompt passes iff it does not.
+- Output: a per-skill pass-rate table, a list of every failing prompt with its predicted skill, and an optional JSON report.
+- Exit code: 0 iff the overall pass rate is at or above the threshold, otherwise 1.
+
+Default judge model is `haiku`: it is the cheapest tier and a stricter test — a description that routes correctly on haiku will route correctly on stronger session models.
+
+## CI
+
+`.github/workflows/skill-evals.yml` — `workflow_dispatch` (with a model input) plus a weekly cron. Requires the `ANTHROPIC_API_KEY` repository secret. Not run on every PR: each full run is ~160 judged prompts and costs real tokens; the consistency workflow already enforces fixture presence and validity on every PR for free.
+
+## Maintenance integration
+
+- `scripts/check-consistency.sh` verifies for every skill: fixture exists, is valid JSON, `skill` field matches the filename, and minimum prompt counts are met.
+- `.claude/hooks/check-dependencies.sh` reminds Claude to revisit `evals/<skill>.json` whenever a SKILL.md is modified.
+- CONTRIBUTING.md and the PR template require a fixture for every new skill.
+
+## Future extensions
+
+- Repeat runs per prompt (Monte Carlo) with pass-rate confidence intervals.
+- Optional `also_acceptable` alternates for prompts with two legitimate routes.
+- A description-optimization loop: hold out 40% of prompts, let a model propose description rewrites, accept only on held-out improvement (the `anthropics/skills` skill-creator pattern).
+- Output-quality evals for generated artifacts (CLAUDE.md sections, rules files) — requires its own spec.

--- a/evals/academic-writing-setup.json
+++ b/evals/academic-writing-setup.json
@@ -1,0 +1,17 @@
+{
+  "skill": "academic-writing-setup",
+  "should_trigger": [
+    "Set up Claude for writing my PhD thesis in LaTeX with strict citation rules and no hallucinated references",
+    "I want Claude to help me draft journal submissions and know my citation style, LaTeX preamble, and section conventions",
+    "Configure Claude to work with my Typst dissertation and enforce a no-invented-citations policy",
+    "I am writing a conference paper and need Claude to know my bibliography tool, document structure, and writing conventions",
+    "Set up Claude so it understands my LaTeX project layout, Zotero Better BibTeX setup, and academic voice rules",
+    "Ich schreibe meine Masterarbeit in LaTeX und moechte, dass Claude korrekte Zitierregeln und meinen Schreibstil kennt"
+  ],
+  "should_not_trigger": [
+    "Help me find papers on transformer architectures and organize them in my Zotero library",
+    "Write the related work section of my paper based on these bullet points",
+    "Set me up for literature review and managing sources across my research project",
+    "Configure Claude to help me produce polished business reports for my manager"
+  ]
+}

--- a/evals/anchors.json
+++ b/evals/anchors.json
@@ -1,0 +1,17 @@
+{
+  "skill": "anchors",
+  "should_trigger": [
+    "The model recommendations in my CLAUDE.md are outdated — re-fetch the latest anchors and update those sections",
+    "Refresh the anchor-derived tool recommendation blocks in my project config files",
+    "The anchor sections in my AGENTS.md are stale — update them with a dry-run preview first",
+    "Pull the latest anchor content and diff it against what is currently in my CLAUDE.md before applying",
+    "Only the anchor-based model and tool guidance blocks need updating in my existing setup",
+    "Die anchor-Abschnitte in meiner CLAUDE.md sind veraltet — bitte nur diese Teile aktualisieren"
+  ],
+  "should_not_trigger": [
+    "Update my full Claude config to the latest plugin defaults and show me diffs for each section",
+    "Run a health check on my setup and decide whether I need a full rebuild or minor improvements",
+    "Give me a read-only audit report of all issues in my current Claude configuration",
+    "Set me up from scratch — I am working on a new research project"
+  ]
+}

--- a/evals/audit-setup.json
+++ b/evals/audit-setup.json
@@ -1,0 +1,17 @@
+{
+  "skill": "audit-setup",
+  "should_trigger": [
+    "Give me a prioritized list of everything wrong with my current Claude configuration without changing anything",
+    "I want a raw findings report on my CLAUDE.md quality, permissions, and MCP setup — no changes applied",
+    "Run a read-only audit of my Claude setup and show me high, medium, and low severity issues",
+    "Show me what is misconfigured or outdated in my Claude settings without touching any files",
+    "Audit my package manager hygiene, git setup, and CLAUDE.md for issues but do not apply any fixes",
+    "Zeig mir alle Probleme in meiner aktuellen Claude-Konfiguration, ohne etwas zu veraendern"
+  ],
+  "should_not_trigger": [
+    "Check whether my existing setup is still good and do whatever is needed to fix it",
+    "Apply the latest best practices to my Claude config and show me diffs before each change",
+    "I am not sure if my setup needs work — just tell me whether to rebuild or improve it",
+    "Refresh the anchor sections in my CLAUDE.md with the latest model recommendations"
+  ]
+}

--- a/evals/checkup.json
+++ b/evals/checkup.json
@@ -1,0 +1,17 @@
+{
+  "skill": "checkup",
+  "should_trigger": [
+    "Is my Claude setup still good or does it need work?",
+    "I set up Claude a few months ago — run the usual maintenance check and tell me what to do",
+    "Check my existing Claude configuration and handle whatever needs fixing",
+    "My onboarding setup feels stale — do a health check and take the right next action",
+    "Verify that my current Claude config still matches current best practices and fix it if not",
+    "Mein Claude-Setup ist schon aelter — mach einen Check und sag mir, ob ich etwas aktualisieren muss"
+  ],
+  "should_not_trigger": [
+    "Give me a prioritized read-only audit of everything wrong with my Claude config",
+    "I already know I need an upgrade — re-apply the latest templates with per-change diffs",
+    "I am brand new to Claude Code and want a personalized setup for my project",
+    "Refresh only the model recommendation anchors in my CLAUDE.md without touching anything else"
+  ]
+}

--- a/evals/coding-setup.json
+++ b/evals/coding-setup.json
@@ -1,0 +1,17 @@
+{
+  "skill": "coding-setup",
+  "should_trigger": [
+    "Configure Claude for my Go microservices repo so it understands our branching and review process",
+    "I want Claude to follow our iterative plan-then-code workflow on this Rust library",
+    "Set up Claude with a disciplined plan-and-review development workflow for my C++ robotics project",
+    "Ich möchte Claude für mein TypeScript-CLI-Projekt mit einem sauberen Subagenten-Workflow einrichten",
+    "Wire up CLAUDE.md and settings.json so Claude knows our commit and PR conventions for this repo",
+    "I need Claude configured to handle brainstorm, planning, and review stages for a Python CLI project"
+  ],
+  "should_not_trigger": [
+    "Help me configure Claude for the Next.js frontend app I'm deploying to Vercel",
+    "Can you write a function that parses this JSON schema for me",
+    "Set up Claude to assist with my Jupyter notebook and experiment tracking",
+    "Is my current Claude setup still following best practices"
+  ]
+}

--- a/evals/content-voice-setup.json
+++ b/evals/content-voice-setup.json
@@ -1,0 +1,17 @@
+{
+  "skill": "content-voice-setup",
+  "should_trigger": [
+    "Configure Claude to always write in our brand voice for LinkedIn posts and newsletters",
+    "I want per-platform voice rules so Claude stays on-brand whether I'm writing tweets or long-form articles",
+    "Set up Claude with our tone-of-voice guidelines so every piece of copy it drafts sounds like us",
+    "Richte Claude so ein, dass es unsere Markenstimme für Instagram-Captions und Blog-Posts konsistent einhält",
+    "We have a defined audience and brand personality — wire that into Claude so it guides all content drafts",
+    "Generate voice rules for Claude tied to our target audience and the platforms we publish on"
+  ],
+  "should_not_trigger": [
+    "Configure Claude to write professional emails and internal memos in our company style",
+    "Can you draft a Twitter thread about our product launch for me",
+    "Set up Claude to publish posts to our social media accounts on a schedule",
+    "Help me configure Claude for academic writing with correct citation style and passive voice"
+  ]
+}

--- a/evals/data-science-setup.json
+++ b/evals/data-science-setup.json
@@ -1,0 +1,17 @@
+{
+  "skill": "data-science-setup",
+  "should_trigger": [
+    "Set up Claude for my ML project — I work in notebooks, track experiments with MLflow, and need reproducibility conventions",
+    "Configure Claude to understand my dataset layout and help me go from exploration to a trained model",
+    "I want Claude wired up for a PyTorch training repo with clean experiment tracking and data versioning",
+    "Richte Claude für mein Scikit-learn-Projekt mit Jupyter-Notebooks und DVC ein",
+    "My project is a Kaggle-style competition pipeline — set up Claude to assist with feature engineering and model iteration",
+    "Get Claude configured for notebook hygiene, data schema documentation, and evaluation protocol in my tabular ML repo"
+  ],
+  "should_not_trigger": [
+    "Help me set up Claude for reading and annotating research papers on machine learning",
+    "Can you train a classifier on this CSV dataset for me",
+    "Configure Claude for a FastAPI service that serves ML model predictions",
+    "Set up Claude for a literature review and thesis writing project in AI"
+  ]
+}

--- a/evals/design-setup.json
+++ b/evals/design-setup.json
@@ -1,0 +1,17 @@
+{
+  "skill": "design-setup",
+  "should_trigger": [
+    "Configure Claude to read my Figma frames directly so it can assist with UI handoff to developers",
+    "I work in Penpot and want Claude wired up to understand my design tokens and component naming",
+    "Set up Claude for my Sketch-based design workflow including MCP integration for frame inspection",
+    "Richte Claude für unsere Figma-Designbibliothek und den Handoff-Prozess ans Entwicklerteam ein",
+    "I want Claude connected to my design tool so it can describe component specs without me copy-pasting",
+    "Wire up the Figma MCP so Claude can inspect frames and generate accurate implementation notes"
+  ],
+  "should_not_trigger": [
+    "Set up Claude for my React frontend with component structure and accessibility rules",
+    "Can you redesign this button component to match our brand colors",
+    "Configure Claude for a full-stack web app with Next.js and Tailwind",
+    "Help me set up Claude to write consistent blog post copy in our brand voice"
+  ]
+}

--- a/evals/devops-setup.json
+++ b/evals/devops-setup.json
@@ -1,0 +1,17 @@
+{
+  "skill": "devops-setup",
+  "should_trigger": [
+    "Set up Claude for our Terraform + AWS infrastructure repo so it pauses before applying destructive changes",
+    "Configure Claude to understand our GitHub Actions pipelines and help review CI/CD changes safely",
+    "I want Claude wired up for cloud engineering — we use Pulumi on GCP and need infra safety rules",
+    "Richte Claude für unser Kubernetes-Cluster-Management mit Helm und ArgoCD ein",
+    "Get Claude ready to help with IaC planning, security review, and safe apply workflows on Azure",
+    "Wire up Claude for a DevOps context — Ansible playbooks, GitOps workflows, and multi-environment deploys"
+  ],
+  "should_not_trigger": [
+    "Set up Claude for my backend Node service that deploys to Vercel",
+    "Can you write a GitHub Actions workflow file for me",
+    "Check if my current Claude setup is still following best practices",
+    "Configure Claude for a Python web app with Docker — it's a product repo, not infrastructure"
+  ]
+}

--- a/evals/graphify-setup.json
+++ b/evals/graphify-setup.json
@@ -1,0 +1,17 @@
+{
+  "skill": "graphify-setup",
+  "should_trigger": [
+    "Install the knowledge-graph tool so Claude stops doing expensive file searches on my large codebase",
+    "I want to wire up a local graph index for my project so Claude can look up symbols and files more cheaply",
+    "Set up the graph-backed PreToolUse hook that reduces token cost when Claude searches across my repository",
+    "I want Claude to build a graph over my docs and code so file lookups hit the graph first",
+    "Configure the open-source graph integration that works with tree-sitter and Markdown for my mixed-media corpus",
+    "Ich will das Knowledge-Graph-Tool einrichten, damit Claude bei grossen Codebasen weniger Token verbraucht"
+  ],
+  "should_not_trigger": [
+    "Set me up for managing a personal Obsidian knowledge base with Claude",
+    "I want Claude to read my Obsidian notes and help me maintain them",
+    "Build a graph visualization of my architecture in a diagram file",
+    "Configure Claude for exploring and summarizing academic papers in my research workflow"
+  ]
+}

--- a/evals/knowledge-base-setup.json
+++ b/evals/knowledge-base-setup.json
@@ -1,0 +1,17 @@
+{
+  "skill": "knowledge-base-setup",
+  "should_trigger": [
+    "Set up Claude to build and maintain an interlinked knowledge base from my personal notes and this codebase",
+    "I want Claude wired up to my Obsidian vault so it can read and write notes via the CLI",
+    "Configure Claude to keep a structured wiki over this project using the LLM wiki pattern",
+    "Richte Claude ein, damit es meine Obsidian-Notizen verwalten und neue Einträge strukturiert anlegen kann",
+    "Drop my source material into a raw folder and have Claude grow a wiki of interlinked markdown notes from it",
+    "Set up a local note-taking workflow where Claude helps me capture and interlink knowledge from multiple sources"
+  ],
+  "should_not_trigger": [
+    "Install the Graphify knowledge-graph tool and register its slash command",
+    "Help me configure Claude for literature review and reading research papers",
+    "Can you summarize the contents of my notes folder",
+    "Set up Claude for academic writing with LaTeX and citation management"
+  ]
+}

--- a/evals/office-setup.json
+++ b/evals/office-setup.json
@@ -1,0 +1,17 @@
+{
+  "skill": "office-setup",
+  "should_trigger": [
+    "I want Claude to help me draft professional emails and internal memos in my company's tone",
+    "Configure Claude so it writes formal business reports and executive summaries for my team",
+    "I spend half my day writing proposals and need Claude to match our corporate style guide",
+    "Help Claude learn how to write client-facing documents and status update emails for my role",
+    "Set up writing conventions so Claude produces clean, on-brand business correspondence",
+    "Ich arbeite viel mit Geschaeftsberichten und moechte, dass Claude meinen professionellen Schreibstil kennt"
+  ],
+  "should_not_trigger": [
+    "Write me a proposal for the Q3 budget right now",
+    "I want Claude to match my personal YouTube channel voice and tone",
+    "Help me build slide decks and presentation templates for board meetings",
+    "Set me up, I am new and not sure which skill I need"
+  ]
+}

--- a/evals/onboarding.json
+++ b/evals/onboarding.json
@@ -1,0 +1,17 @@
+{
+  "skill": "onboarding",
+  "should_trigger": [
+    "I just installed Claude Code and have no idea where to start",
+    "Help me get Claude configured for this project, I'm not sure which setup fits",
+    "New to this tool, can you walk me through getting everything set up?",
+    "I want a personalized Claude setup but I don't know what options exist",
+    "Kannst du mein Projekt scannen und mir sagen, welches Setup am besten passt?",
+    "Set me up properly — I haven't touched any Claude config before"
+  ],
+  "should_not_trigger": [
+    "My existing CLAUDE.md is outdated, can you check if it still matches best practices",
+    "I want to configure Claude specifically for my Python data science notebooks",
+    "Can you review this pull request for me",
+    "What is Claude Code and how does it work"
+  ]
+}

--- a/evals/research-setup.json
+++ b/evals/research-setup.json
@@ -1,0 +1,17 @@
+{
+  "skill": "research-setup",
+  "should_trigger": [
+    "Configure Claude to help me with literature reviews, paper summaries, and citation management in Zotero",
+    "I am starting a new research project and want Claude to understand my field, citation format, and note-taking workflow",
+    "Set up Claude so it can assist with annotated bibliographies and tracking related work across papers",
+    "I need Claude configured so it can help me screen papers for a systematic review and manage my reference library",
+    "I want Claude to help me navigate academic databases, summarize papers, and keep my reference list organized",
+    "Ich mache gerade eine Literaturrecherche fuer meine Dissertation und brauche eine passende Claude-Konfiguration"
+  ],
+  "should_not_trigger": [
+    "Help me write the introduction chapter of my thesis right now",
+    "Set up a LaTeX scaffold and bibliography rules so Claude can help me draft my paper",
+    "Configure Claude for my data science notebooks and experiment tracking",
+    "I want Claude to know my brand voice for my research blog posts"
+  ]
+}

--- a/evals/upgrade-setup.json
+++ b/evals/upgrade-setup.json
@@ -1,0 +1,17 @@
+{
+  "skill": "upgrade-setup",
+  "should_trigger": [
+    "Re-apply the current plugin defaults to my existing Claude setup and show me a diff before each change",
+    "My coding-setup config is months old — update it to the latest best practices with per-change confirmation",
+    "Bring my CLAUDE.md and settings.json in line with the current plugin templates, keeping my customizations",
+    "I already know I want to update my setup — apply current best practices with backup and confirmation prompts",
+    "Run the upgrade against my existing devops-setup sections and show me what would change before writing",
+    "Aktualisiere meine bestehende Claude-Konfiguration auf die aktuellen Standards und frag mich vor jeder Aenderung"
+  ],
+  "should_not_trigger": [
+    "Show me a read-only report of what is wrong with my current Claude config",
+    "I want to check if my setup needs work and let Claude decide the right next step",
+    "Refresh only the anchor-derived model recommendation sections in my CLAUDE.md",
+    "I am brand new — set me up from scratch for software development"
+  ]
+}

--- a/evals/web-development-setup.json
+++ b/evals/web-development-setup.json
@@ -1,0 +1,17 @@
+{
+  "skill": "web-development-setup",
+  "should_trigger": [
+    "Configure Claude for my Next.js app so it respects our API route conventions and Vercel deploy target",
+    "Set up Claude to understand our React frontend with Tailwind and the ESLint rules we enforce",
+    "I want Claude wired up for a full-stack SvelteKit project with a Node backend",
+    "Get Claude ready for my FastAPI + React app — env-var hygiene and linter config are most important",
+    "Richte Claude für unser Django-Backend mit REST-API und Vue-Frontend ein",
+    "Wire up framework permissions and component structure rules for this Astro static site project"
+  ],
+  "should_not_trigger": [
+    "Set up Claude for my Figma-to-code design handoff workflow",
+    "Can you build me a new landing page component in React",
+    "Configure Claude for a Rust CLI library — no HTTP or frontend involved",
+    "Help me set up Claude for my Python machine learning pipeline with notebooks"
+  ]
+}

--- a/scripts/check-consistency.sh
+++ b/scripts/check-consistency.sh
@@ -34,6 +34,33 @@ for dir in "${skill_dirs[@]}"; do
   fi
 done
 
+# Check: every skill has a trigger-eval fixture
+# (see docs/superpowers/specs/2026-06-12-skill-eval-harness-design.md)
+EVALS_DIR="$REPO_ROOT/evals"
+for dir in "${skill_dirs[@]}"; do
+  name="$(basename "$dir")"
+  fixture="$EVALS_DIR/$name.json"
+  if [ ! -f "$fixture" ]; then
+    echo "ERROR: missing trigger-eval fixture evals/$name.json"
+    failed=1
+  elif ! jq . "$fixture" >/dev/null 2>&1; then
+    echo "ERROR: evals/$name.json is not valid JSON"
+    failed=1
+  else
+    fixture_skill="$(jq -r '.skill' "$fixture")"
+    n_trigger="$(jq '.should_trigger | length' "$fixture")"
+    n_reject="$(jq '.should_not_trigger | length' "$fixture")"
+    if [ "$fixture_skill" != "$name" ]; then
+      echo "ERROR: evals/$name.json skill field ($fixture_skill) does not match the filename"
+      failed=1
+    fi
+    if [ "$n_trigger" -lt 5 ] || [ "$n_reject" -lt 3 ]; then
+      echo "ERROR: evals/$name.json needs >=5 should_trigger and >=3 should_not_trigger prompts (has $n_trigger/$n_reject)"
+      failed=1
+    fi
+  fi
+done
+
 legacy_commands=(
   "/build-knowledge-base"
   "/content-creator-setup"

--- a/scripts/check-consistency.sh
+++ b/scripts/check-consistency.sh
@@ -12,11 +12,22 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
-mapfile -t commands < <(jq -r '.commands[].name' "$MANIFEST")
+mapfile -t skill_dirs < <(jq -r '.skills[]' "$MANIFEST")
 
 failed=0
 
-for cmd in "${commands[@]}"; do
+# Slash commands derive from skill directory names; the legacy commands[] field must stay gone.
+if jq -e 'has("commands")' "$MANIFEST" >/dev/null 2>&1; then
+  echo "ERROR: plugin.json contains the legacy commands[] field (removed from the plugin schema; commands derive from skill directory names)"
+  failed=1
+fi
+
+for dir in "${skill_dirs[@]}"; do
+  if [ ! -f "$REPO_ROOT/$dir/SKILL.md" ]; then
+    echo "ERROR: skills[] entry $dir has no SKILL.md (entries must be directories containing SKILL.md)"
+    failed=1
+  fi
+  cmd="$(basename "$dir")"
   if ! grep -q "\`/$cmd\`" "$README"; then
     echo "ERROR: README is missing command /$cmd"
     failed=1
@@ -38,6 +49,33 @@ done
 if grep -q '^- `\.claude/commands/`' "$CLAUDE_DOC"; then
   echo "ERROR: CLAUDE.md still lists .claude/commands/ in key paths"
   failed=1
+fi
+
+# Check: plugin.json version must match the newest ## v... entry in RELEASE-NOTES.md
+manifest_version="$(jq -r '.version' "$MANIFEST")"
+newest_release_version="$(grep -m 1 '^## v' "$RELEASE_NOTES" | sed 's/^## v\([^ ]*\).*/\1/')"
+if [ "$manifest_version" != "$newest_release_version" ]; then
+  echo "ERROR: plugin.json version ($manifest_version) does not match newest RELEASE-NOTES.md entry (v$newest_release_version)"
+  failed=1
+fi
+
+# Check: .claude-plugin/marketplace.json must exist, be valid JSON, and plugins[0].name must equal plugin.json .name
+MARKETPLACE="$REPO_ROOT/.claude-plugin/marketplace.json"
+if [ ! -f "$MARKETPLACE" ]; then
+  echo "ERROR: .claude-plugin/marketplace.json does not exist"
+  failed=1
+else
+  if ! jq . "$MARKETPLACE" >/dev/null 2>&1; then
+    echo "ERROR: .claude-plugin/marketplace.json is not valid JSON"
+    failed=1
+  else
+    marketplace_plugin_name="$(jq -r '.plugins[0].name' "$MARKETPLACE")"
+    manifest_name="$(jq -r '.name' "$MANIFEST")"
+    if [ "$marketplace_plugin_name" != "$manifest_name" ]; then
+      echo "ERROR: marketplace.json plugins[0].name ($marketplace_plugin_name) does not match plugin.json name ($manifest_name)"
+      failed=1
+    fi
+  fi
 fi
 
 if [ "$failed" -ne 0 ]; then

--- a/scripts/run-skill-evals.sh
+++ b/scripts/run-skill-evals.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# Skill trigger eval runner for claude-onboarding-agent.
+#
+# For every prompt in evals/<skill>.json, asks a judge model which skill it
+# would invoke given only the catalog of skill names + frontmatter
+# descriptions, then scores the prediction against the fixture expectation.
+#
+# Usage:
+#   scripts/run-skill-evals.sh [--skill <name>] [--model <alias-or-id>]
+#                              [--threshold <0..1>] [--jobs <n>] [--report <file>]
+#
+# Backends: Anthropic Messages API via curl when ANTHROPIC_API_KEY is set
+# (CI), otherwise the local `claude` CLI in print mode with safe mode enabled
+# so no project context, plugins, or hooks influence the judgment.
+#
+# Spec: docs/superpowers/specs/2026-06-12-skill-eval-harness-design.md
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EVALS_DIR="$REPO_ROOT/evals"
+
+MODEL="haiku"
+THRESHOLD="0.90"
+JOBS=4
+ONLY_SKILL=""
+REPORT=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --skill)     ONLY_SKILL="$2"; shift 2 ;;
+    --model)     MODEL="$2"; shift 2 ;;
+    --threshold) THRESHOLD="$2"; shift 2 ;;
+    --jobs)      JOBS="$2"; shift 2 ;;
+    --report)    REPORT="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+command -v jq >/dev/null 2>&1 || { echo "ERROR: jq is required." >&2; exit 1; }
+[ -d "$EVALS_DIR" ] || { echo "ERROR: $EVALS_DIR does not exist." >&2; exit 1; }
+
+BACKEND="cli"
+if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+  BACKEND="api"
+elif ! command -v claude >/dev/null 2>&1; then
+  echo "ERROR: need either ANTHROPIC_API_KEY (API backend) or the claude CLI on PATH." >&2
+  exit 1
+fi
+
+api_model() {
+  case "$1" in
+    haiku)  echo "claude-haiku-4-5-20251001" ;;
+    sonnet) echo "claude-sonnet-4-6" ;;
+    opus)   echo "claude-opus-4-8" ;;
+    fable)  echo "claude-fable-5" ;;
+    *)      echo "$1" ;;
+  esac
+}
+
+# --- Catalog: name + description from every SKILL.md frontmatter -------------
+build_catalog() {
+  local dir name desc
+  for dir in "$REPO_ROOT"/skills/*/; do
+    [ -f "$dir/SKILL.md" ] || continue
+    name="$(sed -n '/^---$/,/^---$/s/^name:[[:space:]]*//p' "$dir/SKILL.md" | head -1)"
+    desc="$(sed -n '/^---$/,/^---$/s/^description:[[:space:]]*//p' "$dir/SKILL.md" | head -1)"
+    if [ -n "$name" ] && [ -n "$desc" ]; then
+      printf -- '- %s: %s\n' "$name" "$desc"
+    fi
+  done
+}
+CATALOG="$(build_catalog)"
+SKILL_NAMES="$(printf '%s\n' "$CATALOG" | sed 's/^- \([^:]*\):.*/\1/')"
+[ -n "$CATALOG" ] || { echo "ERROR: could not build the skill catalog from skills/*/SKILL.md." >&2; exit 1; }
+
+# --- Judge --------------------------------------------------------------------
+judge() {
+  local user_prompt="$1" full reply
+  full="You are the skill router of a Claude Code plugin. Given the catalog of available skills below and a user message, decide which single skill you would invoke for that message, or none.
+
+Catalog:
+${CATALOG}
+
+Reply with exactly one token: the skill name, or none. No punctuation, no explanation.
+
+User message: ${user_prompt}"
+  if [ "$BACKEND" = "api" ]; then
+    reply="$(curl -sS --max-time 90 https://api.anthropic.com/v1/messages \
+      -H "x-api-key: ${ANTHROPIC_API_KEY}" \
+      -H "anthropic-version: 2023-06-01" \
+      -H "content-type: application/json" \
+      -d "$(jq -cn --arg m "$(api_model "$MODEL")" --arg p "$full" \
+            '{model:$m, max_tokens:16, messages:[{role:"user",content:$p}]}')" \
+      2>/dev/null | jq -r '.content[0].text // empty' 2>/dev/null || true)"
+  else
+    reply="$(CLAUDE_CODE_SAFE_MODE=1 claude -p --model "$MODEL" "$full" 2>/dev/null || true)"
+  fi
+  # Normalize: last non-empty line, strip quotes/backticks/periods, lowercase, trim.
+  reply="$(printf '%s' "$reply" | awk 'NF{l=$0} END{print l}' \
+    | tr -d '`".' | tr '[:upper:]' '[:lower:]' \
+    | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+  if printf '%s\n' "$SKILL_NAMES" | grep -qx -- "$reply"; then
+    printf '%s' "$reply"
+  else
+    printf 'none'
+  fi
+}
+
+run_task() {
+  # $1 = "idx<TAB>skill<TAB>type<TAB>prompt"
+  local idx skill type prompt predicted outcome
+  IFS="$(printf '\t')" read -r idx skill type prompt <<EOF
+$1
+EOF
+  predicted="$(judge "$prompt")"
+  if [ "$type" = "expect" ]; then
+    [ "$predicted" = "$skill" ] && outcome=pass || outcome=fail
+  else
+    [ "$predicted" != "$skill" ] && outcome=pass || outcome=fail
+  fi
+  printf '%s\t%s\t%s\t%s\t%s\n' "$skill" "$type" "$outcome" "$predicted" "$prompt" \
+    > "$RUN_DIR/results/$idx"
+}
+export -f judge run_task api_model
+export CATALOG SKILL_NAMES BACKEND MODEL
+
+RUN_DIR="$(mktemp -d)"
+export RUN_DIR
+trap 'rm -rf "$RUN_DIR"' EXIT
+mkdir -p "$RUN_DIR/results"
+
+# --- Task list ----------------------------------------------------------------
+idx=0
+: > "$RUN_DIR/tasks.tsv"
+for fixture in "$EVALS_DIR"/*.json; do
+  [ -f "$fixture" ] || continue
+  skill="$(jq -r '.skill' "$fixture")"
+  if [ -n "$ONLY_SKILL" ] && [ "$skill" != "$ONLY_SKILL" ]; then
+    continue
+  fi
+  while IFS= read -r p; do
+    idx=$((idx + 1))
+    printf '%s\t%s\t%s\t%s\n' "$idx" "$skill" "expect" "$p" >> "$RUN_DIR/tasks.tsv"
+  done < <(jq -r '.should_trigger[]' "$fixture")
+  while IFS= read -r p; do
+    idx=$((idx + 1))
+    printf '%s\t%s\t%s\t%s\n' "$idx" "$skill" "reject" "$p" >> "$RUN_DIR/tasks.tsv"
+  done < <(jq -r '.should_not_trigger[]' "$fixture")
+done
+total=$idx
+[ "$total" -gt 0 ] || { echo "ERROR: no eval prompts found (check evals/ or --skill filter)." >&2; exit 1; }
+
+echo "Running $total trigger evals (backend: $BACKEND, model: $MODEL, jobs: $JOBS)..."
+tr '\n' '\0' < "$RUN_DIR/tasks.tsv" \
+  | xargs -0 -P "$JOBS" -I{} bash -c 'run_task "$1"' _ {}
+
+completed="$(ls "$RUN_DIR/results" | wc -l | tr -d ' ')"
+if [ "$completed" -ne "$total" ]; then
+  echo "WARNING: $((total - completed)) of $total tasks produced no result (backend errors)." >&2
+fi
+
+cat "$RUN_DIR"/results/* > "$RUN_DIR/all.tsv"
+
+# --- Summary -------------------------------------------------------------------
+echo
+printf '%-26s %8s %8s %10s\n' "skill" "pass" "total" "rate"
+printf '%-26s %8s %8s %10s\n' "-----" "----" "-----" "----"
+awk -F'\t' '
+  { tot[$1]++; if ($3 == "pass") ok[$1]++ }
+  END {
+    for (s in tot) printf "%-26s %8d %8d %9.0f%%\n", s, ok[s], tot[s], 100 * ok[s] / tot[s]
+  }' "$RUN_DIR/all.tsv" | sort
+
+failures="$(awk -F'\t' '$3 == "fail"' "$RUN_DIR/all.tsv" || true)"
+if [ -n "$failures" ]; then
+  echo
+  echo "Failures (skill | type | predicted | prompt):"
+  printf '%s\n' "$failures" | awk -F'\t' '{ printf "  %s | %s | %s | %s\n", $1, $2, $4, $5 }'
+fi
+
+overall="$(awk -F'\t' '{ t++; if ($3 == "pass") p++ } END { printf "%.4f", (t ? p / t : 0) }' "$RUN_DIR/all.tsv")"
+echo
+echo "Overall pass rate: $overall (threshold: $THRESHOLD)"
+
+if [ -n "$REPORT" ]; then
+  jq -Rn --arg model "$MODEL" --arg backend "$BACKEND" --argjson threshold "$THRESHOLD" \
+    --argjson overall "$overall" '
+    [inputs | split("\t") | {skill: .[0], type: .[1], outcome: .[2], predicted: .[3], prompt: .[4]}] as $rows |
+    {
+      model: $model,
+      backend: $backend,
+      threshold: $threshold,
+      overall_pass_rate: $overall,
+      skills: ($rows | group_by(.skill) | map({
+        skill: .[0].skill,
+        total: length,
+        pass: (map(select(.outcome == "pass")) | length)
+      })),
+      failures: ($rows | map(select(.outcome == "fail")))
+    }' < "$RUN_DIR/all.tsv" > "$REPORT"
+  echo "Report written to $REPORT"
+fi
+
+awk -v o="$overall" -v t="$THRESHOLD" 'BEGIN { exit (o + 0 >= t + 0 ? 0 : 1) }'

--- a/skills/_shared/anchor-mapping.md
+++ b/skills/_shared/anchor-mapping.md
@@ -1,6 +1,8 @@
+> Consumed by audit-setup/SKILL.md (Pass 5) and upgrade-setup/SKILL.md (Pass 2). Do not invoke directly.
+
 # Setup → Anchor Mapping
 
-This file is the single source of truth for which anchors each setup type renders. Read by: setup skills (at generation time), `/anchors` (at refresh time), `/tipps` Pass 5, `/upgrade` Pass 2.
+This file is the single source of truth for which anchors each setup type renders. Read by: setup skills (at generation time), `/anchors` (at refresh time), `/audit-setup` Pass 5, `/upgrade-setup` Pass 2.
 
 ## Mapping
 
@@ -25,6 +27,6 @@ This file is the single source of truth for which anchors each setup type render
 
 1. Look up the user's `setup_type` (from `./.claude/onboarding-meta.json` or by asking).
 2. Find the corresponding row in the mapping table.
-3. For each anchor slug in that row, call `skills/_shared/render-anchor-section.md` (setup skills, `/anchors`) or read the anchor for section-based checks (`/tipps`, `/upgrade`).
+3. For each anchor slug in that row, call `skills/_shared/render-anchor-section.md` (setup skills, `/anchors`) or read the anchor for section-based checks (`/audit-setup`, `/upgrade-setup`).
 
 Unknown `setup_type` values: callers must treat this as "no anchors" (degrade gracefully, do not fail).

--- a/skills/_shared/emit-hook.md
+++ b/skills/_shared/emit-hook.md
@@ -1,3 +1,5 @@
+> Consumed by academic-writing-setup/SKILL.md, data-science-setup/SKILL.md, devops-setup/SKILL.md, upgrade-setup/SKILL.md, and web-development-setup/SKILL.md. Do not invoke directly.
+
 # Emit Hook Protocol
 
 This file is read by every setup skill that writes end-user Claude Code hooks into `./.claude/settings.json`. It defines the merge-and-emit procedure so each skill stays focused on its own hook catalog and does not reimplement the file-handling logic.

--- a/skills/_shared/fetch-anchor.md
+++ b/skills/_shared/fetch-anchor.md
@@ -1,3 +1,5 @@
+> Consumed by audit-setup/SKILL.md and checkup/SKILL.md. Do not invoke directly.
+
 # Fetch-Anchor Protocol
 
 This file is read by skills that need a realtime "anchor" document from `docs/anchors/` in the onboarding-agent repo. Anchors are short markdown snapshots that change faster than plugin releases (current model IDs, recommended tooling, MCP servers). Skills fetch them at runtime so users get current content without updating the plugin.

--- a/skills/_shared/graphify-install.md
+++ b/skills/_shared/graphify-install.md
@@ -1,3 +1,5 @@
+> Consumed by coding-setup/SKILL.md, data-science-setup/SKILL.md, graphify-setup/SKILL.md, knowledge-base-setup/SKILL.md, onboarding/SKILL.md, research-setup/SKILL.md, and web-development-setup/SKILL.md. Do not invoke directly.
+
 # Graphify Install Protocol
 
 This file is read by `graphify-setup` AND by host setup skills (coding-setup, knowledge-base-setup, research-setup, data-science-setup, web-development-setup) when the user opts into the Graphify knowledge-graph integration.

--- a/skills/_shared/installation-protocol.md
+++ b/skills/_shared/installation-protocol.md
@@ -1,3 +1,5 @@
+> Consumed by academic-writing-setup/SKILL.md, coding-setup/SKILL.md, content-voice-setup/SKILL.md, data-science-setup/SKILL.md, design-setup/SKILL.md, devops-setup/SKILL.md, knowledge-base-setup/SKILL.md, office-setup/SKILL.md, research-setup/SKILL.md, and web-development-setup/SKILL.md. Do not invoke directly.
+
 # Installation Protocol
 
 This file is read by setup skills during their dependency installation step.

--- a/skills/_shared/migrate-claude-instructions.md
+++ b/skills/_shared/migrate-claude-instructions.md
@@ -1,3 +1,5 @@
+> Consumed by checkup/SKILL.md and upgrade-setup/SKILL.md. Do not invoke directly.
+
 # Migrate claude_instructions/ → .claude/rules/
 
 Shared procedure consumed by the `checkup` and `upgrade` skills. When a user project contains a legacy `claude_instructions/` folder, this procedure offers and executes the migration to the `.claude/rules/` convention. Read before offering migration.
@@ -18,7 +20,7 @@ Only these eight filenames are migrated. Any other file in `claude_instructions/
 |---|---|
 | `writing-style.md` | academic-writing-setup |
 | `citation-rules.md` | academic-writing-setup |
-| `obsidian-cli.md` | knowledge-base-builder |
+| `obsidian-cli.md` | knowledge-base-setup |
 | `data-schema.md` | data-science-setup |
 | `evaluation-protocol.md` | data-science-setup |
 | `api-conventions.md` | web-development-setup |

--- a/skills/_shared/offer-superpowers.md
+++ b/skills/_shared/offer-superpowers.md
@@ -33,7 +33,7 @@ Otherwise ask ONCE (adapt to the detected language, keep coordinates verbatim):
 ```
 Install Superpowers?
 
-<capability_line OR "A free Claude Code skills library (94,000+ users) that adds structured brainstorming, planning, and subagent-driven-development skills used throughout this setup.">
+<capability_line OR "A widely used free Claude Code skills library that adds structured brainstorming, planning, and subagent-driven-development skills used throughout this setup.">
 
 (yes / no)
 ```

--- a/skills/academic-writing-setup/SKILL.md
+++ b/skills/academic-writing-setup/SKILL.md
@@ -45,7 +45,7 @@ Read these on-demand at the step that invokes them. Do not read eagerly.
 
 If cascade mode is active (`source_skill: "research-setup"` AND `superpowers_offered: true` on the handoff context), skip this step entirely — the parent already asked the user and `superpowers_installed` / `superpowers_scope` / `superpowers_method` are already resolved. Do not re-prompt.
 
-Otherwise: read `skills/_shared/offer-superpowers.md` and run it with `skill_slug: academic-writing-setup`, `mandatory: false`, `capability_line: "A free Claude Code skills library (94,000+ users). Brainstorming and planning skills help structure long arguments, chapter outlines, and multi-section revisions."` The helper asks the user, delegates to `skills/_shared/installation-protocol.md` on `yes`, and sets `superpowers_installed`, `superpowers_scope`, `superpowers_method`.
+Otherwise: read `skills/_shared/offer-superpowers.md` and run it with `skill_slug: academic-writing-setup`, `mandatory: false`, `capability_line: "A widely used free Claude Code skills library. Brainstorming and planning skills help structure long arguments, chapter outlines, and multi-section revisions."` The helper asks the user, delegates to `skills/_shared/installation-protocol.md` on `yes`, and sets `superpowers_installed`, `superpowers_scope`, `superpowers_method`.
 
 ## Step 2: Verify Writing Toolchain
 
@@ -146,7 +146,7 @@ Record the emit outcome for use in the completion summary (Step 8). If `emit_sub
 
 ## Step 5: Generate Artifacts
 
-For each file below, if it already exists extend rather than overwrite. Use `<!-- onboarding-agent:start -->` / `<!-- onboarding-agent:end -->` markers for CLAUDE.md; use `# onboarding-agent: academic-writing — start` / `# onboarding-agent: academic-writing — end` markers for `.gitignore`.
+For each file below, if it already exists extend rather than overwrite. Use `<!-- onboarding-agent:start setup=academic-writing skill=academic-writing-setup section=claude-md -->` / `<!-- onboarding-agent:end -->` markers for CLAUDE.md; use `# onboarding-agent: academic-writing — start` / `# onboarding-agent: academic-writing — end` markers for `.gitignore`.
 
 ### CLAUDE.md (≤ 30 lines — pointers only)
 

--- a/skills/academic-writing-setup/optional-integrations.md
+++ b/skills/academic-writing-setup/optional-integrations.md
@@ -57,4 +57,4 @@ Add a short note to the completion summary (do not generate a template file):
 
 ## Knowledge-base bridge
 
-If the user mentions they already ran `knowledge-base-builder` (or a `wiki/` or `notes/` folder exists), tell them: "Claude can read your existing Obsidian vault / wiki notes as research input while drafting — point to them in `.claude/rules/writing-style.md` or by prefixing prompts with the relevant note path."
+If the user mentions they already ran `knowledge-base-setup` (or a `wiki/` or `notes/` folder exists), tell them: "Claude can read your existing Obsidian vault / wiki notes as research input while drafting — point to them in `.claude/rules/writing-style.md` or by prefixing prompts with the relevant note path."

--- a/skills/anchors/SKILL.md
+++ b/skills/anchors/SKILL.md
@@ -132,7 +132,7 @@ Anchor freshness:
    Anchor <anchor_slug> served from <render_freshness> — upstream was unreachable or malformed; re-run /anchors once connectivity returns.]
 
 Next:
-  - Run /tipps to audit the updated setup.
+  - Run /checkup to audit the updated setup.
   - /anchors is idempotent — safe to re-run any time.
 ```
 
@@ -146,16 +146,31 @@ These fallback snapshots are passed to `render-anchor-section.md` when the netwo
 ---
 name: claude-models
 description: Minimal embedded fallback
-last_updated: 2026-04-21
+last_updated: 2026-06-12
 sources: []
-version: 1
+version: 2
 ---
+
+## Model IDs
+
+| Tier   | Model ID              | Alias   | Input/Output (MTok) |
+|--------|-----------------------|---------|---------------------|
+| Fable  | `claude-fable-5`      | `fable` | $10 / $50           |
+| Opus   | `claude-opus-4-8`     | `opus`  | $5 / $25            |
+| Sonnet | `claude-sonnet-4-6`   | `sonnet`| $3 / $15            |
+| Haiku  | `claude-haiku-4-5-20251001` | `haiku` | $1 / $5      |
+
+## Retiring soon
+
+- `claude-sonnet-4-0` and `claude-opus-4-0` retire 2026-06-15 (imminent)
+- `claude-opus-4-1` retires 2026-08-05
 
 ## Defaults
 
-- Coding default: `claude-sonnet-4-6`
-- Deep reasoning: `claude-opus-4-7`
-- High-throughput subagents: `claude-haiku-4-5-20251001`
+- Everyday coding: `claude-sonnet-4-6`
+- Deep reasoning: `claude-opus-4-8`
+- Maximum capability: `claude-fable-5`
+- Fast subagent scans: `claude-haiku-4-5-20251001`
 ```
 
 ### Fallback for `mcp-servers`

--- a/skills/checkup/SKILL.md
+++ b/skills/checkup/SKILL.md
@@ -123,7 +123,7 @@ The plugin owns these subagent filenames under `.claude/agents/`:
 | `component-auditor` | web-development-setup |
 | `notebook-auditor` | data-science-setup |
 | `writing-style-auditor` | academic-writing-setup |
-| `obsidian-vault-keeper` | knowledge-base-builder |
+| `obsidian-vault-keeper` | knowledge-base-setup |
 
 Detection: read `.claude/onboarding-meta.json` and list the slugs in `subagents_installed[]`. Cross-check against `.claude/agents/` on disk. Record the present / missing / unknown slugs as `subagent_state` for reporting in Stage 5.
 

--- a/skills/coding-setup/SKILL.md
+++ b/skills/coding-setup/SKILL.md
@@ -168,7 +168,7 @@ Wrap the generated block in `# onboarding-agent: coding — start` / `— end` m
 
 > "Would you like to install additional community skills?
 >
-> A) frontend-design (official Anthropic) — avoids AI-generic UI, bold design decisions (277k installs)
+> A) frontend-design (official Anthropic) — avoids AI-generic UI, bold design decisions (popular official plugin)
 > B) mcp-builder — create MCP servers for external API integrations
 > C) webapp-testing — Playwright-based UI testing
 > D) security-suite — Trail of Bits CodeQL/Semgrep analysis

--- a/skills/content-voice-setup/SKILL.md
+++ b/skills/content-voice-setup/SKILL.md
@@ -25,13 +25,11 @@ If the delimited block already exists from a previous run, replace only the cont
 Read these on-demand at the step that invokes them. Do not read eagerly.
 
 - `skills/_shared/consume-handoff.md` — orchestrator handoff parse + inline fallback (preamble, before Step 1)
+- `skills/_shared/offer-superpowers.md` — canonical Superpowers opt-in (Step 1)
 
 ## Step 1: Install Dependencies
 
-Read `skills/_shared/installation-protocol.md` and follow it for each dependency below.
-
-Dependencies:
-- Superpowers (optional) — description: "A free Claude Code skills library (94,000+ users). The brainstorming skill is useful for exploring angles before committing to a voice for a given piece." — marketplace-id: `superpowers@claude-plugins-official`, github: `https://github.com/obra/superpowers`, name: `superpowers`
+Read `skills/_shared/offer-superpowers.md` and run it with `skill_slug: content-voice-setup`, `mandatory: false`, `capability_line: "A widely used free Claude Code skills library. The brainstorming skill is useful for exploring angles before committing to a voice for a given piece."` The helper asks the user, delegates to `skills/_shared/installation-protocol.md` on `yes`, and sets `superpowers_installed`, `superpowers_scope`, `superpowers_method`.
 
 ## Step 2: Context Questions
 

--- a/skills/data-science-setup/SKILL.md
+++ b/skills/data-science-setup/SKILL.md
@@ -34,7 +34,7 @@ Read these on-demand at the step that invokes them. Do not read eagerly.
 
 ## Step 1: Install Dependencies
 
-Read `skills/_shared/offer-superpowers.md` and run it with `skill_slug: data-science-setup`, `mandatory: false`, `capability_line: "A free Claude Code skills library (94,000+ users). Useful for planning multi-step experiments and structuring model-training pipelines."` The helper asks the user, delegates to `skills/_shared/installation-protocol.md` on `yes`, and sets `superpowers_installed`, `superpowers_scope`, `superpowers_method`.
+Read `skills/_shared/offer-superpowers.md` and run it with `skill_slug: data-science-setup`, `mandatory: false`, `capability_line: "A widely used free Claude Code skills library. Useful for planning multi-step experiments and structuring model-training pipelines."` The helper asks the user, delegates to `skills/_shared/installation-protocol.md` on `yes`, and sets `superpowers_installed`, `superpowers_scope`, `superpowers_method`.
 
 ## Step 2: Verify Python Tooling
 

--- a/skills/data-science-setup/notebook-hygiene.md
+++ b/skills/data-science-setup/notebook-hygiene.md
@@ -9,14 +9,16 @@ Emit a `.pre-commit-config.yaml` scaffold and instruct the user to run `pre-comm
 ```yaml
 repos:
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.7.1
+    rev: ""  # run: pre-commit autoupdate, or check https://github.com/kynan/nbstripout/releases
     hooks:
       - id: nbstripout
   - repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.8.5
+    rev: ""  # run: pre-commit autoupdate, or check https://github.com/nbQA-dev/nbQA/releases
     hooks:
       - id: nbqa-ruff
       - id: nbqa-black
 ```
+
+After writing this file, run `pre-commit autoupdate` to populate the `rev` fields with the latest stable tags.
 
 If `pre-commit` is not installed, print: "Run `uv add --dev pre-commit && uv run pre-commit install` to activate the hooks."

--- a/skills/data-science-setup/stack-scaffolds.md
+++ b/skills/data-science-setup/stack-scaffolds.md
@@ -10,7 +10,7 @@ Emit a minimal scaffold and instruct the user to run the install commands. Do NO
 [project]
 name = "your-project"
 version = "0.1.0"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = []
 
 [tool.uv]

--- a/skills/design-setup/SKILL.md
+++ b/skills/design-setup/SKILL.md
@@ -27,6 +27,7 @@ If the delimited block already exists from a previous run, replace only the cont
 Read these on-demand at the step that invokes them. Do not read eagerly.
 
 - `skills/_shared/consume-handoff.md` — orchestrator handoff parse + inline fallback (preamble, before Step 1)
+- `skills/_shared/offer-superpowers.md` — canonical Superpowers opt-in (Step 1)
 
 ## Delegated Mode
 
@@ -43,10 +44,7 @@ All other steps still run so the user gets the design-tool CLAUDE.md section and
 
 Skip in delegated mode.
 
-Read `skills/_shared/installation-protocol.md` and follow it for each dependency below.
-
-Dependencies:
-- Superpowers (optional) — description: "A free Claude Code skills library (94,000+ users). The brainstorming skill is useful for exploring design directions and component structures before committing to an implementation." — marketplace-id: `superpowers@claude-plugins-official`, github: `https://github.com/obra/superpowers`, name: `superpowers`
+Read `skills/_shared/offer-superpowers.md` and run it with `skill_slug: design-setup`, `mandatory: false`, `capability_line: "A widely used free Claude Code skills library. The brainstorming skill is useful for exploring design directions and component structures before committing to an implementation."` The helper asks the user, delegates to `skills/_shared/installation-protocol.md` on `yes`, and sets `superpowers_installed`, `superpowers_scope`, `superpowers_method`.
 
 ## Step 2: Context Question
 
@@ -82,7 +80,7 @@ Skip in delegated mode — the parent skill owns this prompt.
 
 Ask ONCE (adapt to detected language):
 
-> "Install the official Anthropic `frontend-design` skill? It avoids AI-generic UI, makes bold design decisions, and is strongly recommended for design-to-code work (277k+ installs). (yes / no)"
+> "Install the official Anthropic `frontend-design` skill? It avoids AI-generic UI, makes bold design decisions, and is strongly recommended for design-to-code work (popular official plugin). (yes / no)"
 
 On `yes`: run `/plugin install frontend-design@claude-plugins-official`. On failure: warn once and continue. Record `frontend-design_installed` accordingly.
 

--- a/skills/devops-setup/SKILL.md
+++ b/skills/devops-setup/SKILL.md
@@ -25,14 +25,12 @@ If the delimited block already exists from a previous run, replace only the cont
 Read these on-demand at the step that invokes them. Do not read eagerly.
 
 - `skills/_shared/consume-handoff.md` — orchestrator handoff parse + inline fallback (preamble, before Step 1)
+- `skills/_shared/offer-superpowers.md` — canonical Superpowers opt-in (Step 1)
 - `rule-file-templates.md` — bodies of the `.claude/rules/*.md` files this skill generates (Step 4)
 
 ## Step 1: Install Dependencies
 
-Read `skills/_shared/installation-protocol.md` and follow it for each dependency below.
-
-Dependencies:
-- Superpowers (optional) — description: "A free Claude Code skills library (94,000+ users). Planning and subagent skills work well for infrastructure tasks that need careful step-by-step execution." — marketplace-id: `superpowers@claude-plugins-official`, github: `https://github.com/obra/superpowers`, name: `superpowers`
+Read `skills/_shared/offer-superpowers.md` and run it with `skill_slug: devops-setup`, `mandatory: false`, `capability_line: "A widely used free Claude Code skills library. Planning and subagent skills work well for infrastructure tasks that need careful step-by-step execution."` The helper asks the user, delegates to `skills/_shared/installation-protocol.md` on `yes`, and sets `superpowers_installed`, `superpowers_scope`, `superpowers_method`.
 
 ## Step 2: Context Questions
 

--- a/skills/office-setup/SKILL.md
+++ b/skills/office-setup/SKILL.md
@@ -25,13 +25,11 @@ If the delimited block already exists from a previous run, replace only the cont
 Read these on-demand at the step that invokes them. Do not read eagerly.
 
 - `skills/_shared/consume-handoff.md` — orchestrator handoff parse + inline fallback (preamble, before Step 1)
+- `skills/_shared/offer-superpowers.md` — canonical Superpowers opt-in (Step 1)
 
 ## Step 1: Install Dependencies
 
-Read `skills/_shared/installation-protocol.md` and follow it for each dependency below.
-
-Dependencies:
-- Superpowers (optional) — description: "A free Claude Code skills library (94,000+ users) with brainstorming and planning workflows for complex tasks." — marketplace-id: `superpowers@claude-plugins-official`, github: `https://github.com/obra/superpowers`, name: `superpowers`
+Read `skills/_shared/offer-superpowers.md` and run it with `skill_slug: office-setup`, `mandatory: false`, `capability_line: "A widely used free Claude Code skills library with brainstorming and planning workflows for complex tasks."` The helper asks the user, delegates to `skills/_shared/installation-protocol.md` on `yes`, and sets `superpowers_installed`, `superpowers_scope`, `superpowers_method`.
 
 ## Step 2: Context Questions
 

--- a/skills/onboarding/SKILL.md
+++ b/skills/onboarding/SKILL.md
@@ -7,6 +7,19 @@ description: Guided onboarding orchestrator — scans your repo, infers your use
 
 Welcome. This skill scans your project, asks you one question, and then configures Claude exactly the way you need it.
 
+## Common rationalizations
+
+The following shortcuts look reasonable but break the onboarding contract. Do not take them.
+
+| Rationalization | Why it does not apply |
+|---|---|
+| "The repo is simple — skip the interview" | Even small setups benefit from an explicit CLAUDE.md section; the interview is 3–7 questions and takes under a minute. |
+| "The user seems expert — generate everything at once" | One question at a time is the contract; experts answer fast anyway and can always press Enter without reading the detail. |
+| "Skip the scan, I can guess the stack" | The repo scan is cheap and prevents wrong-stack artifacts being generated and then undone. |
+| "An existing CLAUDE.md means setup is done" | Existing files get extended with a new delimited section, never skipped or overwritten — Step 1a handles early-exit logic explicitly. |
+| "I know the use case from the question — skip Step 3" | Step 3 presents the full option list so the user can correct an inference; bypassing it removes the user's only confirmation gate. |
+| "The user picked 'not sure' — just recommend the most common path" | Step 4 runs a short decision tree; it reaches a recommendation in at most 3 questions without defaulting to an arbitrary choice. |
+
 ## Argument parsing
 
 The invocation may contain `--rebuild` anywhere in the argument string (as a flag, not a value).

--- a/skills/research-setup/SKILL.md
+++ b/skills/research-setup/SKILL.md
@@ -30,7 +30,7 @@ Read these on-demand at the step that invokes them. Do not read eagerly.
 
 ## Step 1: Install Dependencies
 
-Read `skills/_shared/offer-superpowers.md` and run it with `skill_slug: research-setup`, `mandatory: false`, `capability_line: "A free Claude Code skills library (94,000+ users). Brainstorming and planning skills work well for structuring research arguments and planning complex documents."` The helper asks the user, delegates to `skills/_shared/installation-protocol.md` on `yes`, and sets `superpowers_installed`, `superpowers_scope`, `superpowers_method`.
+Read `skills/_shared/offer-superpowers.md` and run it with `skill_slug: research-setup`, `mandatory: false`, `capability_line: "A widely used free Claude Code skills library. Brainstorming and planning skills work well for structuring research arguments and planning complex documents."` The helper asks the user, delegates to `skills/_shared/installation-protocol.md` on `yes`, and sets `superpowers_installed`, `superpowers_scope`, `superpowers_method`.
 
 ## Step 2: Context Questions
 
@@ -174,7 +174,7 @@ If none match, skip to Step 9. Record `cascade_offered: false`.
 
 If at least one signal matched, ask once (adapt to `detected_language`):
 
-> "Ein Manuskript-Gerüst wurde erkannt ([list matched signals, max 3]). Auch `academic-writing-setup` direkt im Anschluss ausführen? Das konfiguriert die Schreibseite (Stil, Zitationsregeln, LaTeX-Scaffold). (yes / no)"
+> "A manuscript scaffold was detected ([list matched signals, max 3]). Also run academic-writing-setup right after? It configures the writing side (style rules, citation rules, LaTeX scaffold). (yes / no)"
 
 Record the answer as `cascade_accepted`.
 

--- a/skills/upgrade-setup/SKILL.md
+++ b/skills/upgrade-setup/SKILL.md
@@ -47,7 +47,7 @@ Read `./.claude/onboarding-meta.json` if it exists. Expected shape:
 }
 ```
 
-If the file parses and `setup_type` is a recognized slug (one of: `coding`, `data-science`, `design`, `knowledge-base`, `devops`, `content-voice`, `office`, `research`, `academic-writing`), set:
+If the file parses and `setup_type` is a recognized slug (one of: `coding`, `data-science`, `design`, `knowledge-base`, `devops`, `content-voice`, `office`, `research`, `academic-writing`, `web-development`), set:
 
 - `detected_setup: <setup_type>`
 - `detected_skills: <skills_used>`
@@ -143,7 +143,7 @@ For each skill in `detected_skills`, read its `SKILL.md` from the plugin install
 - `./AGENTS.md` (if the skill generates one)
 - `./.gitignore`
 - `./.claude/settings.json` (if the skill generates one)
-- `./.claude/rules/*.md` (if the skill generates any — data-science, academic-writing, web-development, knowledge-base-builder)
+- `./.claude/rules/*.md` (if the skill generates any — data-science, academic-writing, web-development, knowledge-base-setup)
 
 Skip any candidate file that the scan report indicates does not exist. Do not create new files here — Pass 2 is diff-only.
 
@@ -212,7 +212,7 @@ If `anchor_marker_count > 0`, Pass 5 will recommend `/anchors` as the follow-up 
 
 ### Step 2.3 — (Removed)
 
-Anchor-driven checks (deprecated model IDs and similar) now live in `/tipps` Pass 5. Anchor section refreshes are handled by `/anchors`, not by this skill — see the "Anchor responsibilities" note at the top of Pass 2. Nothing to do here.
+Anchor-driven checks (deprecated model IDs and similar) now live in `/audit-setup` Pass 5. Anchor section refreshes are handled by `/anchors`, not by this skill — see the "Anchor responsibilities" note at the top of Pass 2. Nothing to do here.
 
 ### Step 2.4 — Project-Local Subagents
 
@@ -224,7 +224,7 @@ The plugin owns these subagent filenames under `.claude/agents/`:
 | `component-auditor` | web-development-setup |
 | `notebook-auditor` | data-science-setup |
 | `writing-style-auditor` | academic-writing-setup |
-| `obsidian-vault-keeper` | knowledge-base-builder |
+| `obsidian-vault-keeper` | knowledge-base-setup |
 
 Detection and preview rules:
 

--- a/skills/web-development-setup/SKILL.md
+++ b/skills/web-development-setup/SKILL.md
@@ -26,10 +26,10 @@ If the delimited block already exists from a previous run (either the attributed
 
 Read these on-demand at the step that invokes them. Do not read eagerly.
 
-- `rule-file-templates.md` — bodies of the `.claude/rules/*.md` files (Step 6)
+- `rule-file-templates.md` — bodies of the `.claude/rules/*.md` files (Step 8)
 - `framework-defaults.md` — Q1/Q2-conditional styling and deploy-target matrix (Step 4), plus public env-var prefix table
-- `gitignore-block.md` — the `.gitignore` block and `.env.example` scaffold (Step 6)
-- `document-skeletons.md` — `package.json`, `pyproject.toml`, and per-stack install commands (Step 6)
+- `gitignore-block.md` — the `.gitignore` block and `.env.example` scaffold (Step 8)
+- `document-skeletons.md` — `package.json`, `pyproject.toml`, and per-stack install commands (Step 8)
 - `type-check-hook.template.sh` — bash source for the optional type-check PostToolUse hook, with `<PM_EXEC>` placeholder (Step 8)
 - `skills/_shared/consume-handoff.md` — orchestrator handoff parse + inline fallback (preamble, before Step 1)
 - `skills/_shared/offer-superpowers.md` — canonical Superpowers opt-in (Step 1)
@@ -38,7 +38,7 @@ Read these on-demand at the step that invokes them. Do not read eagerly.
 
 ## Step 1: Install Dependencies
 
-Read `skills/_shared/offer-superpowers.md` and run it with `skill_slug: web-development-setup`, `mandatory: false`, `capability_line: "A free Claude Code skills library (94,000+ users). Useful for planning multi-step features, structured brainstorming on routing / data modeling, and subagent-driven refactors across a web stack."` The helper asks the user, delegates to `skills/_shared/installation-protocol.md` on `yes`, and sets `superpowers_installed`, `superpowers_scope`, `superpowers_method`.
+Read `skills/_shared/offer-superpowers.md` and run it with `skill_slug: web-development-setup`, `mandatory: false`, `capability_line: "A widely used free Claude Code skills library. Useful for planning multi-step features, structured brainstorming on routing / data modeling, and subagent-driven refactors across a web stack."` The helper asks the user, delegates to `skills/_shared/installation-protocol.md` on `yes`, and sets `superpowers_installed`, `superpowers_scope`, `superpowers_method`.
 
 ## Step 2: Detect Package Manager
 
@@ -64,7 +64,7 @@ Ask these questions ONE AT A TIME. Wait for each answer before asking the next.
 
 2. **Framework** — "Which frontend framework? (pick 'none' if this is a backend-only repo)
    A) Next.js
-   B) React (plain, Vite or CRA)
+   B) React (plain, Vite)
    C) Vue (Nuxt or plain)
    D) Svelte / SvelteKit
    E) SolidJS (plain or SolidStart)
@@ -118,7 +118,7 @@ After the questions above, ask ONCE (adapt to detected language):
 
   - Pass `delegated_from: web-development-setup` and the current `detected_language` in the handoff context.
   - `design-setup` will run only its Q1 (design tool) and its Figma MCP offer, and write its own delimited CLAUDE.md block + `.gitignore` block. It will NOT emit framework, workflow, or WCAG rules (those are already covered by this skill) and will NOT write its own `.claude/onboarding-meta.json` or anchor sections.
-  - Before invoking, ask ONCE: "Install the official Anthropic `frontend-design` skill? It avoids AI-generic UI and is strongly recommended for design-to-code work (277k+ installs). (yes / no)". On `yes`: run `/plugin install frontend-design@claude-plugins-official`. On failure: warn once and continue. This offer is made here rather than inside `design-setup` so the combined flow prompts for it exactly once.
+  - Before invoking, ask ONCE: "Install the official Anthropic `frontend-design` skill? It avoids AI-generic UI and is strongly recommended for design-to-code work (popular official plugin). (yes / no)". On `yes`: run `/plugin install frontend-design@claude-plugins-official`. On failure: warn once and continue. This offer is made here rather than inside `design-setup` so the combined flow prompts for it exactly once.
   - When this skill's Step 10 writes `./.claude/onboarding-meta.json`, append `"design-setup"` to `skills_used[]`.
 
 ## Step 4: Derive Implied Defaults (do NOT ask)

--- a/skills/web-development-setup/document-skeletons.md
+++ b/skills/web-development-setup/document-skeletons.md
@@ -1,4 +1,4 @@
-> Consumed by web-development-setup/SKILL.md at Step 6. Do not invoke directly.
+> Consumed by web-development-setup/SKILL.md at Step 8. Do not invoke directly.
 
 # Document Skeletons — Web Development Setup
 
@@ -82,7 +82,7 @@ Emit a minimal scaffold and print `uv add` commands — never execute them witho
 [project]
 name = "your-backend"
 version = "0.1.0"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = []
 
 [tool.uv]

--- a/skills/web-development-setup/gitignore-block.md
+++ b/skills/web-development-setup/gitignore-block.md
@@ -1,4 +1,4 @@
-> Consumed by web-development-setup/SKILL.md at Step 6. Do not invoke directly.
+> Consumed by web-development-setup/SKILL.md at Step 8. Do not invoke directly.
 
 # Gitignore and .env.example — Web Development Setup
 

--- a/skills/web-development-setup/rule-file-templates.md
+++ b/skills/web-development-setup/rule-file-templates.md
@@ -1,4 +1,4 @@
-> Consumed by web-development-setup/SKILL.md at Step 6. Do not invoke directly.
+> Consumed by web-development-setup/SKILL.md at Step 8. Do not invoke directly.
 
 # Rule File Templates — Web Development Setup
 


### PR DESCRIPTION
## What does this PR do?

Two stacked changes that bring the repo to the current (June 2026) state of the art, based on a full repo audit plus a research pass over official Claude Code docs and comparable ecosystem repos (anthropics/skills, obra/superpowers, wshobson/agents, claude-plugins-official).

### Commit 1 — `refresh: June 2026 state-of-the-art update` (v1.1.0)

**Anchors (`docs/anchors/`)**
- `claude-models`: adds the Fable 5 tier and Opus 4.8, current pricing/limits, imminent retirements (`claude-sonnet-4-0`/`claude-opus-4-0` retire 2026-06-15), tokenizer note
- `claude-tools`: new hook events, settings keys, slash commands, SKILL.md frontmatter fields
- `mcp-servers`: concrete install commands (official GitHub MCP server replaces the archived `@modelcontextprotocol/server-github`, Figma, Google Workspace), SSE deprecation note
- `subagents`: new frontmatter fields, model-tiering guidance

**Plugin manifest migrated to the current schema**
- `skills[]` now lists `./`-prefixed skill directories; the legacy `commands[]` field is removed (slash commands derive from directory names, descriptions from SKILL.md frontmatter)
- `claude plugin validate` now passes (previously failed on both fields)
- New self-hosted `marketplace.json`: `/plugin marketplace add a2ngerer/claude_onboarding_agent` works; README/installation docs updated accordingly

**Consistency fixes**
- `/tipps` phantom references removed; `knowledge-base-builder` -> `knowledge-base-setup` rename completed across 8 files (this silently broke checkup/upgrade subagent detection)
- `upgrade-setup` now recognizes the `web-development` slug; `upgrade-planner` path reference fixed
- Dependents hook derives the repo root portably instead of a hardcoded absolute path; dead case pattern fixed
- `check-consistency.sh`: version match against release notes, marketplace.json validation, skills[] entry checks

**Modernization**
- Plugin subagents tiered: haiku for scanners, sonnet for planners (was opus everywhere)
- Domain skills: CRA dropped, Python >=3.12, pre-commit revs unpinned, frozen install counts removed, four skills migrated to the shared Superpowers offer helper, hardcoded German cascade prompt in research-setup replaced with an English template, attributed CLAUDE.md markers in academic-writing-setup

### Commit 2 — `feat: add skill trigger eval harness` (v1.2.0)

Closes the main gap versus the ecosystem: nothing previously detected skill-routing regressions.

- `evals/<skill>.json` fixtures for all 16 skills (6 should-trigger prompts incl. one German, 4 near-miss should-not-trigger each)
- `scripts/run-skill-evals.sh`: judges each prompt against the live catalog (Anthropic API or `claude` CLI in safe mode), per-skill pass rates, JSON report, threshold gate
- `.github/workflows/skill-evals.yml`: weekly + on-demand runs
- Fixture presence/validity enforced on every PR via `check-consistency.sh`; new-skill checklists require a fixture
- Spec: `docs/superpowers/specs/2026-06-12-skill-eval-harness-design.md`

## Example output

Baseline run (haiku judge): **96.9% overall (155/160)**. Two genuine routing findings are intentionally kept as failing/flaky fixtures for a future description-optimization pass:

1. `audit-setup` prompts route to `checkup` — audit-setup's own description defers to /checkup
2. `research-setup` literature/citation prompts flicker to `academic-writing-setup` — description overlap on writing and citation format

## Notes for review

- The `skill-evals.yml` workflow needs the `ANTHROPIC_API_KEY` repository secret before its first run.
- `.github/workflows/` (claude.yml, claude-code-review.yml, update-anchors.yml) and the `code.claude.com` trend-source URL were deliberately left untouched (audit findings there did not hold up under verification).
- Checklist in the PR template targets new-skill PRs and does not apply here.