### PR TITLE
Sharpen overlapping skill descriptions per trigger-eval findings

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "claude-onboarding-agent",
   "displayName": "Claude Onboarding Agent",
   "description": "Guided setup for Claude Code — generates tailored CLAUDE.md, AGENTS.md, and config files for any use case in minutes.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": {
     "name": "Alexander Angerer",
     "email": "alexander.angerer@outlook.de"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Not sure where to start? Run `/onboarding` and we'll figure it out with you. Or 
 | **A data scientist / ML engineer** | `/data-science-setup` | Notebook hygiene, experiment tracking, `data/raw→processed` layout, reproducibility |
 | **Building a personal wiki / second brain** | `/knowledge-base-setup` | Karpathy-pattern wiki, optional Obsidian CLI subagent |
 | **Writing emails, memos, reports, proposals** | `/office-setup` | Business-writing focus: Q1 branches guidelines (email path vs. report path); presentations out of scope |
-| **A researcher or academic** | `/research-setup` | Citation format, domain vocabulary, LaTeX-aware ignores |
+| **A researcher or academic** | `/research-setup` | Literature review workflow, Zotero reference management, reading notes |
 | **Writing a thesis, paper, or dissertation** | `/academic-writing-setup` | Thesis / paper / dissertation — LaTeX or Typst, Zotero, citation rules that prevent hallucinations |
 | **Creator brand voice** (YouTube, shortform, newsletter, podcast) | `/content-voice-setup` | Voice + audience + per-platform rule files — scope limited to writing guidance; publishing / analytics / media production out of scope |
 | **Running infra / DevOps** | `/devops-setup` | Cloud + IaC + CI config, safe-by-default infra workflow |
@@ -98,7 +98,7 @@ irm https://raw.githubusercontent.com/a2ngerer/claude_onboarding_agent/main/scri
 | `/data-science-setup` | Notebook workflow (Jupyter/marimo), experiment tracking (MLflow/W&B/DVC), reproducible `pyproject.toml`, `data/raw/interim/processed` layout, model-card pointers |
 | `/knowledge-base-setup` | Builds a [Karpathy-pattern](https://github.com/forrestchang/andrej-karpathy-skills) wiki from your notes or codebase (+ optional [Obsidian](https://obsidian.md) CLI integration via dispatched subagent — no always-on MCP token cost) |
 | `/office-setup` | Business writing — emails, memos, reports, proposals. Q1 bifurcates emitted guidelines (email path / report path / both); presentations are out of scope |
-| `/research-setup` | Citation format, research domain, academic writing guidelines |
+| `/research-setup` | Input side of academic research — literature reviews, paper screening and summaries, Zotero reference management, reading notes. Manuscript drafting lives in `/academic-writing-setup` |
 | `/academic-writing-setup` | Thesis / paper / dissertation setup — LaTeX or Typst stack, Zotero + Better BibTeX, citation style, no-invented-citations rules, `sections/`/`bib/`/`figures/` scaffold |
 | `/content-voice-setup` | Creator brand voice for YouTube / shortform / newsletter / podcast. Emits per-platform rule files under `.claude/rules/` (`youtube.md`, `shortform.md`, `newsletter.md`, `podcast.md`) keyed to the platforms Q1 selects. Scope limited to writing guidance — publishing, analytics, thumbnails, and media production are out of scope |
 | `/devops-setup` | Cloud provider, IaC tool, CI/CD — safe infra workflow + agent roles |
@@ -106,7 +106,7 @@ irm https://raw.githubusercontent.com/a2ngerer/claude_onboarding_agent/main/scri
 | `/graphify-setup` | Installs [Graphify](https://github.com/safishamsi/graphify) (25-language tree-sitter + Markdown + PDF + media indexer). Registers `/graphify query / path / explain` and a PreToolUse hook consulted before file-search tool calls — cuts token cost on large codebases and mixed-media corpora. Safe to layer on top of any other setup |
 | `/checkup` | The single maintenance entrypoint. Runs the audit, weighs findings + meta age + deprecated-model anchors, and either prints a short "fine-as-is" summary, hands off to `/upgrade-setup`, or invokes `/onboarding --rebuild`. Call this whenever you want to know whether your setup still matches current best practices |
 | `/anchors` | Refresh anchor-derived marker sections in CLAUDE.md/AGENTS.md against the latest upstream anchors |
-| `/audit-setup` | Power-user / internal tool — normal flow is `/checkup`. Audits your existing Claude setup (permissions, CLAUDE.md quality, git hygiene, tooling) and returns a prioritized improvement list |
+| `/audit-setup` | Read-only power-user tool — normal flow is `/checkup`. Audits your existing Claude setup (permissions, CLAUDE.md quality, git hygiene, tooling) and returns a prioritized HIGH/MEDIUM/LOW findings list without changing any files |
 | `/upgrade-setup` | Power-user / internal tool — normal flow is `/checkup`. Re-applies current best practices to an existing setup: per-change diff preview, dry-run flag, timestamped backups, never touches content outside the plugin's delimited sections |
 
 ---

--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## v1.2.1 — 2026-06-12
+
+Skill description sharpening, driven by trigger-eval findings.
+
+- `audit-setup` description now leads with its read-only, report-only nature instead of "normally invoked via /checkup", which steered the eval judge (and users browsing the catalog) to `/checkup`
+- `checkup` description no longer mentions running `/audit-setup` internally; it now emphasizes the decide-and-act contract ("checked and fixed, not just a findings report")
+- `research-setup` description is scoped to the input side of academic research (literature reviews, paper screening, Zotero reference management, reading notes) and points manuscript drafting to `academic-writing-setup` — removes the overlap that caused flaky routing of literature prompts
+- README tables updated to match the new positioning
+- Eval fixtures unchanged — descriptions were verified against the existing fixtures per the optimization loop in the eval-harness design doc
+
 ## v1.2.0 — 2026-06-12
 
 Skill trigger eval harness.

--- a/skills/audit-setup/SKILL.md
+++ b/skills/audit-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: audit-setup
-description: Power-user tool — normally invoked via /checkup. Audit your current Claude setup and get a prioritized list of improvement suggestions — package manager hygiene, CLAUDE.md quality, permissions, git hygiene, MCP servers, and more.
+description: Read-only audit of your current Claude setup — prints a prioritized HIGH/MEDIUM/LOW findings list covering package manager hygiene, CLAUDE.md quality, permissions, git hygiene, and MCP servers, without changing any files. Power-user stage of /checkup — invoke directly when you want the raw findings report without a verdict or follow-up actions.
 ---
 
 # Audit Setup — Claude Setup Audit

--- a/skills/checkup/SKILL.md
+++ b/skills/checkup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: checkup
-description: The single user-facing maintenance entrypoint. Runs /audit-setup internally, weighs findings + meta age + deprecated-model anchors, and either prints a short "fine-as-is" summary, hands off to /upgrade-setup, or invokes /onboarding --rebuild.
+description: The single user-facing maintenance entrypoint for an existing Claude setup. Health-checks your configuration, decides whether it is fine as-is, needs an upgrade, or needs a rebuild, and takes that action — handing off to /upgrade-setup or /onboarding --rebuild as needed. Use when you want your setup checked and fixed, not just a findings report.
 ---
 
 # Checkup — Single Maintenance Entrypoint

--- a/skills/research-setup/SKILL.md
+++ b/skills/research-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research-setup
-description: Set up Claude for academic research and writing — configures citation format, research domain, and writing tool preferences so Claude supports your workflow from literature review to final paper.
+description: Set up Claude for the input side of academic research — literature reviews, paper screening and summaries, reference management with Zotero, annotated bibliographies, and reading notes for your research domain. For drafting the manuscript itself, use academic-writing-setup.
 ---
 
 # Research Setup


### PR DESCRIPTION
Supersedes #43, which GitHub closed automatically when the base branch of #42 was deleted on merge. Content is identical; #42 is now merged, so this targets main directly.

## Summary

Implements the description-optimization step documented in the eval-harness design doc (Future Extensions): sharpen the two overlapping description pairs that the eval baseline surfaced, verified against the unchanged fixtures.

### Changes

**audit-setup vs checkup** (2 baseline failures): audit-setup's description led with "Power-user tool — normally invoked via /checkup", which routed read-only audit prompts to checkup. It now leads with the read-only findings-report contract ("prints a prioritized HIGH/MEDIUM/LOW findings list ... without changing any files") and keeps the power-user note at the end. checkup's description no longer mentions running /audit-setup internally and instead emphasizes its decide-and-act contract ("checked and fixed, not just a findings report").

**research-setup vs academic-writing-setup** (flaky, 80-90% across baseline runs): research-setup claimed "academic research and writing ... citation format ... to final paper", colliding with academic-writing-setup's vocabulary. It is now scoped to the input side of academic research (literature reviews, paper screening and summaries, Zotero reference management, reading notes) and explicitly defers manuscript drafting to academic-writing-setup. academic-writing-setup and upgrade-setup were already at 10/10 and are untouched.

Also: README tables aligned with the new positioning, version bumped to 1.2.1 with a release-notes entry.

### Verification

- Full eval suite: 160/160 (baseline: 96.9% with audit-setup at 8/10 and research-setup flaky)
- research-setup: 10/10 in three consecutive runs (full suite + two targeted reruns) — flakiness resolved
- Fixtures unchanged — only descriptions moved
- scripts/check-consistency.sh passes; claude plugin validate passes (known harmless contributors warning only)

### Review notes

- Descriptions are user-visible (slash-command catalog), hence the separate PR
- docs/superpowers/plans/2026-04-16-onboarding-agent.md still contains the original research-setup description; left as-is since plan docs are historical records