### PR TITLE
Bump actions/checkout to v6 and upload-artifact to v7

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq

--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # The runner has no local `claude` CLI, so the script needs the API
       # backend. Skip gracefully (green run + warning) until the secret is
@@ -52,7 +52,7 @@ jobs:
 
       - name: Upload report
         if: always() && steps.key.outputs.present == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: skill-eval-report
           path: eval-report.json

--- a/.github/workflows/update-anchors.yml
+++ b/.github/workflows/update-anchors.yml
@@ -13,7 +13,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run Claude Code to research and update anchors
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
## Summary

The skill-evals test run surfaced a deprecation annotation: Node 20 actions are forced onto Node 24 starting 2026-06-16 (four days from now) and Node 20 is removed from runners on 2026-09-16. All five workflows pinned `actions/checkout@v4` (Node 20); `skill-evals.yml` also pinned `actions/upload-artifact@v4`.

This bumps `checkout` to v6 and `upload-artifact` to v7 — the current majors, both on Node 24. `anthropics/claude-code-action@v1` is already on its current major and is untouched. No workflow logic changes; the used inputs (`fetch-depth`, artifact `name`/`path`/`if-no-files-found`) are unchanged across these majors.

## Verification

- All five workflow files parse cleanly as YAML
- The consistency check on this PR itself exercises the bumped checkout@v6