### PR TITLE
feat(knowledge-base): conform generated wiki to Google OKF v0.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "claude-onboarding-agent",
   "displayName": "Claude Onboarding Agent",
   "description": "Guided setup for Claude Code — generates tailored CLAUDE.md, AGENTS.md, and config files for any use case in minutes.",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "author": {
     "name": "Alexander Angerer",
     "email": "alexander.angerer@outlook.de"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Not sure where to start? Run `/onboarding` and we'll figure it out with you. Or 
 | **A developer** shipping code | `/coding-setup` | Superpowers workflow, subagent roles, stack permissions |
 | **Building a web app** (frontend, backend, or full-stack) | `/web-development-setup` | Frontend, backend, or full-stack web app — framework-aware permissions, env-var hygiene, deploy-target pointers |
 | **A data scientist / ML engineer** | `/data-science-setup` | Notebook hygiene, experiment tracking, `data/raw→processed` layout, reproducibility |
-| **Building a personal wiki / second brain** | `/knowledge-base-setup` | Karpathy-pattern wiki, optional Obsidian CLI subagent |
+| **Building a personal wiki / second brain** | `/knowledge-base-setup` | OKF v0.1 (Karpathy-pattern) wiki, optional Obsidian CLI subagent |
 | **Writing emails, memos, reports, proposals** | `/office-setup` | Business-writing focus: Q1 branches guidelines (email path vs. report path); presentations out of scope |
 | **A researcher or academic** | `/research-setup` | Literature review workflow, Zotero reference management, reading notes |
 | **Writing a thesis, paper, or dissertation** | `/academic-writing-setup` | Thesis / paper / dissertation — LaTeX or Typst, Zotero, citation rules that prevent hallucinations |
@@ -96,7 +96,7 @@ irm https://raw.githubusercontent.com/a2ngerer/claude_onboarding_agent/main/scri
 | `/coding-setup` | Installs [Superpowers](https://github.com/obra/superpowers), wires up brainstorm → plan → subagents → review → commit |
 | `/web-development-setup` | Framework-aware web-app setup — Next.js / React / Vue / Svelte / SolidJS / Astro / Remix + optional backend (Node/Bun/Python/Go). API conventions, component structure, env-var hygiene, deploy-target pointers |
 | `/data-science-setup` | Notebook workflow (Jupyter/marimo), experiment tracking (MLflow/W&B/DVC), reproducible `pyproject.toml`, `data/raw/interim/processed` layout, model-card pointers |
-| `/knowledge-base-setup` | Builds a [Karpathy-pattern](https://github.com/forrestchang/andrej-karpathy-skills) wiki from your notes or codebase (+ optional [Obsidian](https://obsidian.md) CLI integration via dispatched subagent — no always-on MCP token cost) |
+| `/knowledge-base-setup` | Builds a [Karpathy-pattern](https://github.com/forrestchang/andrej-karpathy-skills) wiki from your notes or codebase, conformant to Google's [Open Knowledge Format (OKF v0.1)](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) so the bundle stays portable across OKF-aware agents (+ optional [Obsidian](https://obsidian.md) CLI integration via dispatched subagent — no always-on MCP token cost) |
 | `/office-setup` | Business writing — emails, memos, reports, proposals. Q1 bifurcates emitted guidelines (email path / report path / both); presentations are out of scope |
 | `/research-setup` | Input side of academic research — literature reviews, paper screening and summaries, Zotero reference management, reading notes. Manuscript drafting lives in `/academic-writing-setup` |
 | `/academic-writing-setup` | Thesis / paper / dissertation setup — LaTeX or Typst stack, Zotero + Better BibTeX, citation style, no-invented-citations rules, `sections/`/`bib/`/`figures/` scaffold |
@@ -157,7 +157,7 @@ Every setup skill creates a tailored `CLAUDE.md` with context and instructions s
 | Coding | ✓ + workflow | ✓ 3 roles (AGENTS.md) + opt-in `code-reviewer` subagent | ✓ stack permissions | ✓ stack | — | Superpowers + opt-in GitHub MCP |
 | Web Development | ✓ + pointers (`.claude/rules/api-conventions.md`, `component-structure.md`, `env-vars.md`) | opt-in `component-auditor` subagent | ✓ framework + package-manager + deploy-CLI permissions | ✓ `node_modules/`, framework build outputs (`.next/`, `dist/`, `.astro/`, …), `.env.local`, test artifacts | ✓ type-check on save (TS only, opt-in) | Superpowers (optional) + opt-in GitHub MCP |
 | Data Science | ✓ + pointers (`.claude/rules/data-schema.md`, `evaluation-protocol.md`) | opt-in `notebook-auditor` subagent | ✓ uv / notebook / tracker permissions | ✓ raw data, notebook checkpoints, experiment artifacts | ✓ nbstripout on save (opt-in) | Superpowers (optional) |
-| Knowledge Base | ✓ + Karpathy pattern | ✓ `.claude/agents/obsidian-vault-keeper.md` (optional) | — | ✓ | — | Superpowers + Karpathy |
+| Knowledge Base | ✓ + Karpathy / OKF v0.1 bundle (`wiki/` + `index.md` / `log.md`) | ✓ `.claude/agents/obsidian-vault-keeper.md` (optional) | — | ✓ | — | Superpowers + Karpathy |
 | Office | ✓ + writing style | — | — | ✓ | — | Superpowers (optional) + opt-in Gmail / Calendar / Drive MCP |
 | Research | ✓ + citation format | — | — | ✓ LaTeX | — | Superpowers (optional) |
 | Academic Writing | ✓ + non-negotiable citation rules (pointers to `.claude/rules/writing-style.md`, `citation-rules.md`) | opt-in `writing-style-auditor` subagent | — | ✓ LaTeX / Typst build artifacts | ✓ SessionStart rules reload (opt-in) | Superpowers (optional) |
@@ -178,7 +178,9 @@ Brainstorm idea → Write plan → Dispatch subagents → Code review → Commit
 
 The Knowledge Base Setup sets up the [Karpathy LLM Wiki pattern](https://github.com/forrestchang/andrej-karpathy-skills): a `raw/` folder for source material and a `wiki/` folder of interlinked markdown notes that Claude builds and maintains. Drop files into `raw/`, ask Claude to ingest them — the wiki grows automatically.
 
-Optional: connect [Obsidian](https://obsidian.md) via the official Obsidian CLI, wired into a dedicated `obsidian-vault-keeper` subagent. Vault reads/writes only load the CLI reference when actually invoked, so chats that don't touch the vault pay zero Obsidian tokens — unlike a persistent MCP whose tool schemas are loaded into every session.
+The generated `wiki/` is an [**OKF v0.1 bundle**](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) — Google Cloud's Open Knowledge Format, the published, vendor-neutral standard that formalizes the LLM-wiki pattern. Each note is one concept with YAML frontmatter (a required `type` plus recommended `title` / `description` / `tags` / `timestamp`), reserved `index.md` / `log.md` files, and standard Markdown cross-links (not wikilinks). Conformance keeps the knowledge base portable across any OKF-aware agent or tool, not just Claude.
+
+Optional: connect [Obsidian](https://obsidian.md) via the official Obsidian CLI, wired into a dedicated `obsidian-vault-keeper` subagent. Obsidian renders OKF frontmatter as native Properties and Markdown links in its graph view, so the bundle stays both OKF-conformant and fully navigable. Vault reads/writes only load the CLI reference when actually invoked, so chats that don't touch the vault pay zero Obsidian tokens — unlike a persistent MCP whose tool schemas are loaded into every session.
 
 ---
 

--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -1,5 +1,17 @@
 # Release Notes
 
+## v1.3.0 — 2026-06-30
+
+Knowledge base conforms to Google's Open Knowledge Format (OKF v0.1).
+
+- `knowledge-base-setup` now generates an OKF v0.1 bundle: every `wiki/` concept note carries YAML frontmatter with a required `type` plus recommended `title` / `description` / `resource` / `tags` (list) / `timestamp`, and the bundle seeds reserved `index.md` (directory listing, no frontmatter) and `log.md` (chronological history)
+- Cross-links switched from Obsidian `[[wikilinks]]` to standard Markdown links (bundle-relative or relative) so the bundle is portable to any OKF-aware agent or tool; wikilinks remain an optional Obsidian-only convenience
+- OKF-conformant note / `index.md` / `log.md` skeletons, the linking rule, the `type` vocabulary, the conformance self-check, and the Obsidian reconciliation extracted to `skills/knowledge-base-setup/document-skeletons.md` (SKILL.md was over the 300-line modularization threshold)
+- `obsidian-vault-keeper` subagent and `obsidian-cli.md` reference updated to require frontmatter with a non-empty `type` on every new concept note
+- `knowledge-base` anchor (`docs/anchors/knowledge-base.md`) reframed around OKF frontmatter (added the OKF spec + Google Cloud blog to its sources, version bumped to 2)
+- README "What's Inside", "Pick your path", and "What gets generated" tables plus the knowledge-base section updated to describe OKF conformance
+- Design: `docs/superpowers/specs/2026-06-30-okf-conformance-design.md`
+
 ## v1.2.1 — 2026-06-12
 
 Skill description sharpening, driven by trigger-eval findings.

--- a/docs/anchors/knowledge-base.md
+++ b/docs/anchors/knowledge-base.md
@@ -1,66 +1,82 @@
 ---
 name: knowledge-base
-description: Recommended vault layouts, frontmatter patterns, and KB-agent structures for Obsidian-style knowledge bases
-last_updated: 2026-04-21
+description: Recommended vault layouts, OKF v0.1 frontmatter patterns, and KB-agent structures for Obsidian-style knowledge bases
+last_updated: 2026-06-30
 sources:
+  - https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md
+  - https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing
   - https://help.obsidian.md/
   - https://help.obsidian.md/properties
   - https://publish.obsidian.md/hub/01+-+Community+Vaults
-version: 1
+version: 2
 ---
 
 ## Vault layout
 
-The plugin's recommended layout separates raw material from curated notes. `raw/` holds ingested source files (articles, PDFs, code, notes); `wiki/` holds the interlinked note graph produced from that raw material. Extra top-level folders only when justified by scale.
+The plugin's recommended layout separates raw material from curated notes. `raw/` holds ingested source files (articles, PDFs, code, notes); `wiki/` holds the interlinked note graph produced from that raw material. The `wiki/` folder is an **OKF v0.1 bundle** (Google's Open Knowledge Format), so it stays portable across any OKF-aware agent or tool. Extra top-level folders only when justified by scale.
 
 ```
 vault/
 ├── raw/           ← drop source material here (ingestion input)
-├── wiki/          ← curated, interlinked notes (Karpathy LLM-Wiki pattern)
+├── wiki/          ← OKF v0.1 bundle (curated, interlinked concept notes)
+│   ├── index.md   ← OKF directory listing (reserved; no frontmatter)
+│   ├── log.md     ← OKF update history (reserved; optional)
 │   └── README.md
 ├── templates/     ← note templates (optional)
 └── .obsidian/     ← vault config, plugins, workspace state
 ```
 
+## OKF v0.1 conformance
+
+OKF (Open Knowledge Format) is Google Cloud's published standard for the Karpathy LLM-wiki pattern: a directory of Markdown concept files, one concept per file, cross-linked with standard Markdown links. A bundle conforms when:
+
+1. Every non-reserved `.md` file carries a parseable YAML frontmatter block.
+2. Every such block has a non-empty `type` (the single required key).
+3. Reserved filenames — `index.md` (per-directory listing, no frontmatter) and `log.md` (optional chronological history) — follow their structures when present.
+
+Everything else is soft: missing optional fields, unknown `type` values, custom keys, and broken links never invalidate a bundle. Concepts link with Markdown links (`[Title](note.md)` or bundle-relative `[Title](/folder/note.md)`), **not** `[[wikilinks]]` — OKF consumers cannot parse wikilinks.
+
 ## Frontmatter conventions
 
-Obsidian properties live in YAML frontmatter delimited by `---`. Reserved keys have typed behavior in the UI; custom keys are free-form.
+Notes carry OKF frontmatter in YAML delimited by `---`. Obsidian renders these as native *Properties*, so OKF and Obsidian agree on the same block. OKF requires exactly one key (`type`) and recommends five more.
 
-| Property | Type | Required | Purpose |
+| Property | OKF status | Type | Purpose |
 |---|---|---|---|
-| `title` | text | No | Display title when it differs from the filename |
-| `created` | date | Recommended | ISO-8601 creation timestamp (UTC) |
-| `updated` | date | Recommended | ISO-8601 modification timestamp |
-| `tags` | list | Recommended | Hierarchical tags (`topic/subtopic`); enables dataview queries |
-| `aliases` | list | No | Alternate names that resolve in wikilinks and search |
-| `type` | text | Recommended | Custom discriminator (`concept`, `person`, `project`, `daily`) |
+| `type` | **Required** | text | Kind of concept (`concept`, `module`, `person`, `reference`, …); free-form string |
+| `title` | Recommended | text | Human-readable display name when it differs from the filename |
+| `description` | Recommended | text | Single-sentence summary (used for index generation and search previews) |
+| `resource` | Recommended | text | URI uniquely identifying the underlying asset (omit for prose notes) |
+| `tags` | Recommended | list | Categorization strings (`[graphs, retrieval]`); enables dataview queries |
+| `timestamp` | Recommended | date | ISO 8601 datetime of the last meaningful change |
 
-Reserved Obsidian keys: `aliases`, `tags`, `cssclasses`. Dates use `YYYY-MM-DD` or ISO-8601 with time; lists may use YAML block or flow syntax.
+Real bundles emit keys in the order `type, resource, title, description, tags, timestamp`. Producers may add custom keys (e.g. `aliases`, `created`, `updated`); OKF consumers preserve unknown keys. If a vault already uses Obsidian's `created`/`updated`, keep OKF's single `timestamp` as canonical and let the others coexist as extensions. Reserved Obsidian keys (`aliases`, `tags`, `cssclasses`) keep their typed UI behavior. Dates use ISO 8601; lists may use YAML block or flow syntax.
 
 ## Naming conventions
 
-- Kebab-case filenames (`knowledge-graphs.md`), not snake_case or PascalCase. Wikilink-friendly.
-- No date prefixes on topical notes — dates go in `created:` frontmatter, not the filename.
+- Kebab-case filenames (`knowledge-graphs.md`), not snake_case or PascalCase. Link- and wikilink-friendly.
+- No date prefixes on topical notes — dates go in `timestamp:` frontmatter, not the filename.
 - Daily notes: `YYYY-MM-DD.md` under a dedicated `daily/` folder only.
 - Avoid reserved characters: `:`, `/`, `\`, `?`, `*`, `"`, `<`, `>`, `|`. Obsidian rejects them on write.
 - One concept per note — resist multi-topic dumps. Break out subtopics into linked notes.
+- `index.md` and `log.md` are reserved OKF filenames — do not use them as topical concept notes.
 
 ## Agent patterns
 
-- **Vault keeper** — dispatched subagent owning all vault I/O via the Obsidian CLI. Forbids direct `Edit`/`Write` so wikilinks and backlinks stay consistent. Reference: `.claude/agents/obsidian-vault-keeper.md`.
-- **Frontmatter validator** — reads notes, checks required keys (`created`, `updated`, `tags`, `type`), reports missing/malformed entries. Read-only, Haiku-class model.
+- **Vault keeper** — dispatched subagent owning all vault I/O via the Obsidian CLI. Forbids direct `Edit`/`Write` so links and backlinks stay consistent. Reference: `.claude/agents/obsidian-vault-keeper.md`.
+- **Frontmatter validator** — reads notes, enforces OKF conformance (non-empty `type` on every non-reserved note; recommended keys present), reports missing/malformed entries. Read-only, Haiku-class model.
 - **Tag normalizer** — scans `tags:` across the vault, flags near-duplicates (`ai`, `AI`, `artificial-intelligence`), proposes a canonical form. Read-only.
-- **Ingester** — watches `raw/` for new files, summarizes into `wiki/` notes with backlinks into related concepts. Write-capable; dispatched only on explicit user request.
+- **Ingester** — watches `raw/` for new files, summarizes into `wiki/` concept notes with frontmatter and Markdown backlinks, refreshes `index.md` and `log.md`. Write-capable; dispatched only on explicit user request.
 
 ## Recommended layout
 
-**`raw/` + `wiki/` (Karpathy LLM-Wiki pattern).** Exactly two top-level folders: `raw/` for ingested material, `wiki/` for curated, interlinked notes. Templates and daily notes go into dedicated subfolders (`templates/`, `daily/`) only when they are actually used. Vault ops are routed through the `obsidian-vault-keeper` subagent so the Obsidian CLI owns every write.
+**`raw/` + `wiki/` (Karpathy LLM-Wiki pattern, OKF v0.1).** Exactly two top-level folders: `raw/` for ingested material, `wiki/` for the OKF concept-note bundle. Templates and daily notes go into dedicated subfolders (`templates/`, `daily/`) only when they are actually used. Vault ops are routed through the `obsidian-vault-keeper` subagent so the Obsidian CLI owns every write.
 
 ## Anti-patterns
 
-- Deeply nested topical folders (`wiki/tech/programming/python/django/models/`) — defeats wikilinks, buries notes from the graph view.
+- Deeply nested topical folders (`wiki/tech/programming/python/django/models/`) — defeats links, buries notes from the graph view.
 - Mixing daily notes with topical notes in one folder — date prefixes pollute the index and the graph.
-- Frontmatter type drift — `tags: "one, two"` (string) vs. `tags: [one, two]` (list) across notes breaks dataview queries.
+- Frontmatter type drift — `tags: "one, two"` (string) vs. `tags: [one, two]` (list) across notes breaks dataview queries; a missing or empty `type` breaks OKF conformance.
+- Wikilink-only cross-linking — `[[note]]` is invisible to OKF consumers. Use Markdown links; treat wikilinks as optional Obsidian-only sugar.
 - Editing vault files with plain `Edit`/`Write` or `mv` — skips Obsidian's link-rewrite logic and silently corrupts backlinks.
 - Using the third-party Obsidian MCP for vault I/O — its tool schemas load into every session. Prefer the official CLI plus the vault-keeper subagent.
-- Dumping raw source material into `wiki/` — `wiki/` is for curated notes only; raw inputs belong in `raw/`.
+- Dumping raw source material into `wiki/` — `wiki/` is for curated OKF concept notes only; raw inputs belong in `raw/`.

--- a/docs/superpowers/specs/2026-06-30-okf-conformance-design.md
+++ b/docs/superpowers/specs/2026-06-30-okf-conformance-design.md
@@ -1,0 +1,100 @@
+# OKF v0.1 Conformance for the Knowledge Base — Design
+
+**Date:** 2026-06-30
+**Status:** Implemented (v1.3.0)
+
+## Context
+
+`knowledge-base-setup` builds a Karpathy LLM-wiki: a `raw/` folder for source
+material and a `wiki/` folder of interlinked Markdown notes. Until now the note
+format was ad hoc — a one-line summary, an inline `tags: #a #b` line, a body, and
+a `## Related: [[wikilink]]` footer.
+
+On 2026-06-12 Google Cloud published the **Open Knowledge Format (OKF)**, a
+vendor-neutral specification that formalizes exactly this LLM-wiki pattern into a
+portable, interoperable format. An OKF bundle is just a directory of Markdown
+files with YAML frontmatter — no SDK, no runtime, no manifest. Aligning the
+generated wiki to OKF makes every knowledge base this plugin produces portable to
+any OKF-aware agent or tool, at no cost to the existing workflow.
+
+Spec: <https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md>
+
+## OKF v0.1 in brief
+
+Verified against the official spec, the reference bundles in
+`GoogleCloudPlatform/knowledge-catalog`, the Google Cloud announcement blog, and
+independent explainers:
+
+- **One concept per file.** Every non-reserved `.md` file is one concept.
+- **Required frontmatter:** exactly one key — `type`, a non-empty free-form
+  string. No closed enumeration; real bundles use as few as three values
+  (`BigQuery Table`, `BigQuery Dataset`, `Reference`) and distinguish purpose via
+  `tags`.
+- **Recommended frontmatter** (priority order): `title`, `description`,
+  `resource`, `tags` (a YAML list), `timestamp` (ISO 8601). Real bundles emit
+  keys in the order `type, resource, title, description, tags, timestamp`.
+- **Reserved filenames:** `index.md` (per-directory listing for progressive
+  disclosure; carries no frontmatter) and `log.md` (optional chronological
+  history; `YYYY-MM-DD` headings, newest first, entries prefixed with a bold
+  action word).
+- **Cross-linking:** standard Markdown links to `.md` files — absolute
+  bundle-relative (`/path`) or relative. Untyped relationships; broken links
+  tolerated. Wikilinks are not part of OKF.
+- **Conformance (hard):** parseable frontmatter on every non-reserved file;
+  non-empty `type`; reserved files follow their structures when present.
+  Everything else is soft.
+
+## Decision
+
+Make the generated `wiki/` an OKF v0.1 bundle by default.
+
+1. **Concept note format → OKF frontmatter.** Replace the summary/`tags:`/Related
+   convention with YAML frontmatter (`type` required; `title`, `description`,
+   `tags`, `timestamp` recommended; `resource` when an external asset exists),
+   an H2/H3 body, and a `## Related` section of Markdown links.
+2. **Links → Markdown, not wikilinks.** Canonical cross-links are Markdown links
+   (bundle-relative preferred). Wikilinks become an optional Obsidian-only
+   convenience, never a replacement.
+3. **Seed reserved files.** Setup creates `wiki/index.md` (seeded listing, no
+   frontmatter) and `wiki/log.md` (seeded with a `**Creation**` entry) so the
+   bundle is conformant from the first commit. Ingestion keeps both current.
+4. **Conformance self-check.** Ingestion ends with the OKF self-check
+   (frontmatter present, non-empty `type`, Markdown links).
+
+## Obsidian reconciliation
+
+OKF and Obsidian do not conflict. Obsidian renders YAML frontmatter as native
+Properties and Markdown links in its graph view, and `obsidian move` rewrites
+Markdown links. `tags:` as a list (no leading `#`) is what Obsidian already
+expects. The single OKF `timestamp` is canonical; a vault's existing
+`created`/`updated` keys coexist as extension fields. The `obsidian-vault-keeper`
+subagent is instructed to write frontmatter with a non-empty `type` on every new
+note.
+
+## Modularization
+
+`skills/knowledge-base-setup/SKILL.md` was already over the 300-line
+modularization threshold. The OKF skeletons, linking rule, `type` vocabulary,
+conformance self-check, and Obsidian reconciliation move to the sibling
+`document-skeletons.md` (a canonical sibling filename per the repo's
+modularization convention), read on-demand at Step 3. SKILL.md keeps the step
+ordering, the generated `wiki/README.md` and CLAUDE.md blocks, and a pointer to
+the sibling.
+
+## Files changed
+
+- `skills/knowledge-base-setup/document-skeletons.md` — new sibling (OKF skeletons + rules)
+- `skills/knowledge-base-setup/SKILL.md` — description, folder structure, seeded `index.md`/`log.md`, OKF note format, ingestion conformance, vault-keeper frontmatter rule, completion summary
+- `docs/anchors/knowledge-base.md` — OKF frontmatter conventions + conformance section; sources + version bump
+- `README.md` — "Pick your path", "What's Inside", "What gets generated", and the knowledge-base section
+- `skills/onboarding/SKILL.md` — knowledge-base menu line notes the OKF bundle
+- `.claude-plugin/plugin.json` — version bump to 1.3.0
+- `docs/RELEASE-NOTES.md` — v1.3.0 entry
+
+## Out of scope
+
+- `graphify-setup` builds a knowledge *graph* (a queryable index), not an
+  LLM-wiki, so OKF does not apply to it.
+- No OKF validator tool ships with the plugin; conformance is enforced by the
+  ingestion self-check, not by external tooling (consistent with OKF's
+  "no required SDK" stance).

--- a/skills/knowledge-base-setup/SKILL.md
+++ b/skills/knowledge-base-setup/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: knowledge-base-setup
-description: Set up Claude to build and maintain a structured knowledge base using the Karpathy LLM Wiki pattern — works with codebases, personal notes, or both. Integrates with Obsidian via the official Obsidian CLI (token-efficient, dispatched through a dedicated subagent — no always-on MCP overhead).
+description: Set up Claude to build and maintain a structured knowledge base using the Karpathy LLM Wiki pattern, conformant to Google's Open Knowledge Format (OKF v0.1) — works with codebases, personal notes, or both. Integrates with Obsidian via the official Obsidian CLI (token-efficient, dispatched through a dedicated subagent — no always-on MCP overhead).
 ---
 
 # Knowledge Base Setup
 
-This skill configures Claude to build and maintain a structured, interlinked knowledge base using the Karpathy LLM Wiki pattern.
+This skill configures Claude to build and maintain a structured, interlinked knowledge base using the Karpathy LLM Wiki pattern. The generated `wiki/` is an **OKF v0.1 bundle** — Google Cloud's Open Knowledge Format, the published, vendor-neutral standard that formalizes the LLM-wiki pattern (a directory of Markdown concept files with YAML frontmatter, cross-linked with standard Markdown links). Conformance keeps the knowledge base portable across any OKF-aware agent or tool, not just Claude.
 
 **Handoff context:** Read `skills/_shared/consume-handoff.md` and run it with the handoff block (if any). The helper guarantees the following locals: `detected_language`, `existing_claude_md`, `inferred_use_case`, `repo_signals`, `graphify_candidate`. Use `detected_language` for all user-facing prose; generated file content stays in English.
 
@@ -26,6 +26,7 @@ Read these on-demand at the step that invokes them. Do not read eagerly.
 
 - `skills/_shared/consume-handoff.md` — orchestrator handoff parse + inline fallback (preamble, before Step 1)
 - `skills/_shared/offer-superpowers.md` — canonical Superpowers opt-in (Step 1)
+- `document-skeletons.md` — OKF-conformant concept-note / index.md / log.md skeletons, linking rule, type vocabulary, conformance self-check, Obsidian reconciliation (Step 3)
 - `skills/_shared/offer-graphify.md` — canonical Graphify opt-in (Step 4)
 
 ## Step 1: Install Dependencies
@@ -88,33 +89,41 @@ Ask one at a time, waiting for each answer:
 
 ## Step 3: Generate Artifacts
 
+Read `document-skeletons.md` first — it holds the OKF-conformant concept-note, `index.md`, and `log.md` skeletons, the linking rule, the `type` vocabulary, and the conformance self-check. Use those skeletons verbatim as the basis for every artifact below.
+
 ### Folder Structure
 
-Create the following in the target path from question 3:
+The `wiki/` folder is an **OKF v0.1 bundle**. Seed it so it is conformant from the first commit. Create the following in the target path from question 3:
 ```
 [target_path]/
-├── raw/          ← drop source material here (articles, code files, PDFs, notes)
-└── wiki/
-    └── README.md ← overview of the wiki structure
+├── raw/              ← drop source material here (articles, code files, PDFs, notes)
+└── wiki/             ← OKF v0.1 bundle (one concept per .md file)
+    ├── index.md      ← OKF directory listing (reserved filename, no frontmatter)
+    ├── log.md        ← OKF update history (reserved filename, optional)
+    └── README.md     ← how to use the bundle
 ```
 
-`wiki/README.md`:
+Write `wiki/index.md` from the `index.md` skeleton in `document-skeletons.md` (no frontmatter, a `# Knowledge Base — Index` heading, and a placeholder note that concepts appear here after the first ingestion). Write `wiki/log.md` from the `log.md` skeleton, seeded with today's date and a `**Creation**` entry. Then write `wiki/README.md`:
+
 ```markdown
 # Knowledge Base
 
-Built with Claude using the Karpathy LLM Wiki pattern.
+Built with Claude using the Karpathy LLM Wiki pattern. This `wiki/` folder is an
+**OKF v0.1 bundle** (Google's Open Knowledge Format), so it stays portable across
+any OKF-aware agent or tool.
 
 ## How to Use
 
 **Adding sources:** Drop files into `raw/`. Then ask Claude: "Ingest the new files in raw/ and update the wiki."
 
-**Wiki structure:** Each note in `wiki/` covers one concept, person, project, or topic. Notes link to related notes using [[wikilinks]].
+**Bundle structure:** Each note in `wiki/` is one OKF concept — a person, project, module, or topic. `index.md` lists what's available; `log.md` records updates. Notes link to related notes with standard Markdown links.
 
-**Note format:**
-- First line: one-sentence summary
-- Second line: `tags: #topic #subtopic`
-- Body: structured content with headers
-- Last section: `## Related: [[linked-note-1]], [[linked-note-2]]`
+**Concept note format (OKF v0.1):**
+- YAML frontmatter with a required `type` (free-form string) plus recommended `title`, `description`, `tags` (a list), `timestamp` (ISO 8601). Add `resource` when the note describes an external asset.
+- Body: structured content with H2/H3 headers.
+- A `## Related` section linking related notes with Markdown links — `[Title](note.md)` or bundle-relative `[Title](/folder/note.md)`. Not `[[wikilinks]]`: OKF consumers cannot parse them.
+
+**Reserved filenames:** `index.md` (directory listing, no frontmatter) and `log.md` (chronological history). Every other `.md` is a concept document.
 ```
 
 ### Obsidian integration files (ONLY if `obsidian_cli_available: true`)
@@ -138,6 +147,7 @@ Read `.claude/rules/obsidian-cli.md` for the full command reference and output f
 ## Rules
 - Use the `obsidian` CLI via Bash exclusively. Never edit vault files with Edit/Write — wikilinks and backlinks depend on Obsidian's own APIs (e.g. `obsidian move` rewrites links, a plain `mv` does not).
 - Obsidian must be running. If a command errors with "Obsidian is not running", ask the caller to open Obsidian, then retry once.
+- Notes in `wiki/` are OKF concept documents: every new note created with `obsidian create` must carry YAML frontmatter with a non-empty `type`, and link to related notes with Markdown links (not wikilinks). `index.md` and `log.md` are reserved — `index.md` has no frontmatter.
 - Prefer structured output: append `format=json` or `format=paths` when supported. It parses smaller and cleaner than prose.
 - For multi-step operations (e.g. search → move all matches), pipe `format=paths` through a shell loop rather than issuing commands one note at a time.
 - Return a compact summary — operation name, counts, paths affected. Do NOT dump note contents unless explicitly asked.
@@ -170,6 +180,8 @@ Official Obsidian CLI (desktop 1.12.4+). Requires the Obsidian app to be running
 - `obsidian append file="path/to/note" content="..."` — append to an existing note
 - `obsidian prepend file="path/to/note" content="..."` — insert after frontmatter
 
+When creating OKF concept notes, the `content=` value must start with a YAML frontmatter block carrying a non-empty `type`. Reserved `index.md` files carry no frontmatter.
+
 ## Search
 - `obsidian search query="term"` — fulltext search
 - `obsidian search:context query="term" limit=10` — include surrounding lines
@@ -180,7 +192,7 @@ Official Obsidian CLI (desktop 1.12.4+). Requires the Obsidian app to be running
 - `obsidian tags` — list every tag in the vault
 
 ## Move / Delete
-- `obsidian move file="note" to="folder/"` — moves and rewrites wikilinks automatically
+- `obsidian move file="note" to="folder/"` — moves and rewrites links automatically (wikilinks and Markdown links)
 - `obsidian delete file="note"` — move to system trash
 - `obsidian delete file="note" permanent` — delete permanently
 
@@ -190,7 +202,7 @@ Supported values for `format=`: `json`, `csv`, `tsv`, `md`, `paths`, `text`, `tr
 ## Troubleshooting
 - "Obsidian is not running" → open Obsidian, retry.
 - "Unknown command" → run `obsidian help` to list commands for the installed version.
-- Wikilinks broke after moving a file → always use `obsidian move`, never Finder/`mv`.
+- Links broke after moving a file → always use `obsidian move`, never Finder/`mv`.
 ```
 
 ### CLAUDE.md
@@ -203,41 +215,49 @@ Target path: [answer from Q3]
 Source material: [answer from Q1]
 Source language: [answer from Q4]
 
-## Workflow — Karpathy LLM Wiki Pattern
+## Workflow — Karpathy LLM Wiki Pattern (OKF v0.1)
 [Include ONLY if superpowers_installed is true]
 At the start of every new conversation, invoke the `using-superpowers` skill.
 
+The `wiki/` folder is an OKF v0.1 bundle (Google's Open Knowledge Format). Keep it
+conformant so it stays portable across OKF-aware agents and tools.
+Spec: https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md
+
 ### Structure
 - `raw/` — source material (never modify files here)
-- `wiki/` — organized, interlinked knowledge notes
+- `wiki/` — OKF bundle: organized, interlinked concept notes
+  - `wiki/index.md` — directory listing (reserved; no frontmatter)
+  - `wiki/log.md` — chronological update history (reserved; optional)
 
-### Note Format
-Every wiki note must have:
-1. First line: one-sentence summary of the topic
-2. Second line: `tags: #tag1 #tag2`
-3. Body: structured content with H2/H3 headers
-4. Last section: `## Related: [[note1]], [[note2]]`
+### Concept Note Format (OKF v0.1)
+Every wiki note (except reserved `index.md` / `log.md`) must have:
+1. YAML frontmatter with a required `type` (free-form string, e.g. `concept`, `module`, `person`, `reference`), plus recommended `title`, `description`, `tags` (a YAML list, no leading `#`), and `timestamp` (ISO 8601). Add `resource` (a URI) when the note describes an external asset.
+2. Body: structured content with H2/H3 headers.
+3. A `## Related` section linking related notes with **Markdown links** — `[Title](note.md)` or bundle-relative `[Title](/folder/note.md)`. Never `[[wikilinks]]` — OKF consumers cannot parse them.
 
 ### Ingestion Process
 When asked to ingest new material from raw/:
 1. Read the source file
 2. Extract key concepts, facts, and insights
-3. Create or update wiki notes — one note per concept
-4. Link new notes to related existing notes using [[wikilinks]]
-5. Update existing notes if new material adds to them
+3. Create or update wiki notes — one OKF concept document per concept, each with valid frontmatter (non-empty `type`)
+4. Link new notes to related existing notes using Markdown links
+5. Update existing notes if new material adds to them, and refresh their `timestamp`
 6. Do NOT delete or overwrite existing wiki content — only extend it
+7. Update `wiki/index.md` so new concepts are listed, and append a dated entry to `wiki/log.md`
+8. Run the OKF conformance self-check (see the skill's `document-skeletons.md`): every non-reserved `.md` has parseable frontmatter with a non-empty `type`; links are Markdown links, not wikilinks
 
 ### For Codebases
 When documenting code:
-1. Create one wiki note per module/package/component
+1. Create one OKF concept note per module/package/component, `type:` set to `module` / `component` / `service` / `api` as appropriate
 2. Note: purpose, public API, key dependencies, important design decisions
-3. Link to notes about dependencies
-4. Maintain a `wiki/architecture.md` overview that links to all component notes
+3. Link to notes about dependencies with Markdown links
+4. Maintain a `wiki/architecture.md` overview (`type: reference`) that links to all component notes
 
 ## Obsidian
 [Include if obsidian_cli_available is true]
 Obsidian vault ops run through the `obsidian-vault-keeper` subagent (see `.claude/agents/obsidian-vault-keeper.md`). **Always dispatch that agent via the Agent tool** for reads, writes, searches, moves, or deletes on the vault — do not shell out to `obsidian` directly from this thread and do not edit vault files with Edit/Write.
 Command reference: `.claude/rules/obsidian-cli.md` (read-on-demand; the subagent handles this automatically).
+Obsidian renders OKF YAML frontmatter as native Properties and Markdown links in the graph view, so the bundle stays both OKF-conformant and fully navigable in Obsidian. Wikilinks remain an optional Obsidian-only convenience — Markdown links are canonical.
 Why a subagent: keeps CLI schema out of the main context window, so chats that don't touch the vault cost zero Obsidian tokens.
 
 [Include if obsidian_cli_available is false]
@@ -303,9 +323,11 @@ For every call, also capture `render_freshness`. When it is anything other than 
 ✓ Knowledge Base setup complete!
 
 Files created:
-  CLAUDE.md                              — Karpathy-pattern workflow instructions
+  CLAUDE.md                              — Karpathy-pattern / OKF v0.1 workflow instructions
   [target]/raw/                          — drop source material here
-  [target]/wiki/                         — your knowledge base will be built here
+  [target]/wiki/                         — your OKF v0.1 knowledge bundle will be built here
+  [target]/wiki/index.md                 — OKF directory listing (seeded)
+  [target]/wiki/log.md                   — OKF update history (seeded)
   [target]/wiki/README.md                — how to use your knowledge base
   [if obsidian_cli_available]
     .claude/agents/obsidian-vault-keeper.md — subagent that owns vault I/O
@@ -330,6 +352,7 @@ Anchor freshness:
 Next steps:
   Drop files into [target]/raw/
   Start a new Claude session and say: "Ingest the files in raw/ and build the wiki"
+  Your wiki/ is an OKF v0.1 bundle — portable to any OKF-aware agent or tool.
   [if obsidian_cli_available] For vault ops, just ask — Claude will dispatch the obsidian-vault-keeper agent automatically.
   [if graphify_installed] Try: /graphify query "which notes mention <topic>?"
   - Run `/anchors` any time to refresh the anchor-derived sections. If any section was rendered as a placeholder due to offline mode, re-run `/anchors` once you are back online.

--- a/skills/knowledge-base-setup/document-skeletons.md
+++ b/skills/knowledge-base-setup/document-skeletons.md
@@ -1,0 +1,135 @@
+# Document Skeletons — OKF-conformant wiki bundle
+
+> Consumed by knowledge-base-setup/SKILL.md at Step 3 (artifact generation) and referenced by the generated CLAUDE.md ingestion workflow. Do not invoke directly. Do not read eagerly.
+
+The `wiki/` folder this skill produces is an **OKF v0.1 bundle** — Google Cloud's
+Open Knowledge Format, the published standard for the Karpathy LLM-wiki pattern.
+A bundle is just a directory of Markdown files: one concept per file, a small
+YAML frontmatter block per concept, and standard Markdown links between them.
+Spec: https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md
+
+## OKF in one screen
+
+- **One concept per file.** Every non-reserved `.md` file describes a single
+  concept (a topic, person, project, module, API, dataset, …).
+- **Required frontmatter:** exactly one key — `type`, a non-empty free-form
+  string identifying the kind of concept.
+- **Recommended frontmatter** (priority order): `title`, `description`,
+  `resource`, `tags` (a YAML list), `timestamp` (ISO 8601 of the last meaningful
+  change). Real bundles emit them in the order `type, resource, title,
+  description, tags, timestamp`.
+- **Two reserved filenames:** `index.md` (per-directory listing, no frontmatter)
+  and `log.md` (optional chronological history). Every other `.md` is a concept.
+- **Links are standard Markdown links to `.md` files — never wikilinks.**
+  OKF consumers parse Markdown links; `[[wikilinks]]` are invisible to them.
+
+## Concept note skeleton
+
+Write one file per concept. Filename is kebab-case (`knowledge-graphs.md`).
+
+```markdown
+---
+type: concept
+title: Knowledge Graphs
+description: One-sentence summary of what this note covers.
+resource: https://example.com/source   # optional — URI of the underlying asset; omit for prose notes
+tags: [graphs, retrieval]
+timestamp: 2026-06-30T12:00:00+00:00
+---
+
+# Knowledge Graphs
+
+Structured body with H2/H3 headers — definitions, key facts, design decisions.
+
+## Related
+- [Embeddings](embeddings.md) — how vectors back the graph
+- [Vector Search](/references/vector-search.md) — bundle-relative link
+```
+
+`type` is required; everything else is recommended-but-optional. Keep `type`
+first. Omit `resource` when there is no external asset.
+
+### `type` vocabulary
+
+Free-form strings, producer-chosen — there is no closed enumeration. Pick a small,
+consistent set and reuse it:
+
+- **Notes / second brain:** `concept`, `person`, `project`, `topic`, `reference`
+- **Codebases:** `module`, `component`, `service`, `api`, `reference`
+
+Distinguish finer purpose with `tags`, not by inventing one `type` per note
+(real OKF bundles use as few as three distinct `type` values and lean on tags).
+
+## `index.md` skeleton (reserved — no frontmatter)
+
+A plain-Markdown directory listing for progressive disclosure: a reader scans the
+index before opening individual notes. No YAML frontmatter. Group entries under
+headings; each entry is a relative Markdown link plus a one-line description.
+
+```markdown
+# Knowledge Base — Index
+
+## Concepts
+- [Knowledge Graphs](knowledge-graphs.md) — graph-structured knowledge representation
+- [Embeddings](embeddings.md) — dense vector representations of meaning
+
+## Subdirectories
+- [references](references/index.md) — supporting reference notes
+```
+
+Give every subdirectory its own `index.md` following the same pattern.
+
+## `log.md` skeleton (reserved — optional)
+
+Chronological update history, newest date first. ISO 8601 `YYYY-MM-DD` date
+headings; each entry is prefixed with a bold action word (`**Creation**`,
+`**Update**`). Optional — per-note `timestamp` frontmatter already records change
+time, so a `log.md` is only worth keeping when a human-readable changelog helps.
+
+```markdown
+# Update Log
+
+## 2026-06-30
+- **Creation** Initialized the OKF knowledge bundle.
+```
+
+## Linking rule
+
+Concepts link to each other with **standard Markdown links to `.md` files**. Two
+forms are valid:
+
+- **Absolute (bundle-relative):** begins with `/`, e.g. `/references/vector-search.md`.
+  Stable when notes move — prefer this for cross-directory links.
+- **Relative:** standard relative path, e.g. `../references/metrics.md`.
+
+A link asserts an untyped relationship; surrounding prose conveys the meaning.
+Broken links are tolerated — a missing target never invalidates the bundle.
+
+## Conformance self-check
+
+Run this after every ingestion. The bundle conforms to OKF v0.1 when:
+
+1. Every non-reserved `.md` file has a parseable YAML frontmatter block.
+2. Every such block has a non-empty `type`.
+3. `index.md` files carry no frontmatter and list children as Markdown links.
+4. `log.md`, if present, uses `YYYY-MM-DD` headings, newest first.
+5. Concept links are Markdown links to `.md` files, not `[[wikilinks]]`.
+
+Everything else is soft: missing optional fields, unknown `type` values, custom
+frontmatter keys, and broken links are all allowed.
+
+## Obsidian reconciliation
+
+OKF and Obsidian coexist cleanly — no either/or:
+
+- **Frontmatter is native.** Obsidian renders YAML frontmatter as *Properties*;
+  `tags:` as a list (no leading `#`) is exactly what Obsidian expects.
+- **Markdown links render in the graph view** and `obsidian move` rewrites them,
+  so OKF's canonical Markdown links keep backlinks and the graph intact.
+- **Wikilinks stay optional.** `[[note]]` is an Obsidian convenience that OKF
+  consumers cannot parse. Prefer Markdown links for portability; if a user insists
+  on wikilinks, treat them as Obsidian-only sugar layered on top of the canonical
+  Markdown link, not a replacement.
+- **`timestamp` maps onto Obsidian dates.** Use the single OKF `timestamp` key; if
+  a vault already uses `created`/`updated`, keep `timestamp` as the OKF-canonical
+  field and let the others coexist as extension keys.

--- a/skills/onboarding/SKILL.md
+++ b/skills/onboarding/SKILL.md
@@ -165,7 +165,7 @@ _Your repo is large — `/graphify-setup` can layer on top of any choice in this
 **Writing & Research**
 5. Academic Writing — thesis / paper / dissertation: LaTeX or Typst, Zotero, strict no-invented-citations rules (manuscript side)
 6. Research & Academic Writing — literature, papers, LaTeX (reading and note-taking side)
-7. Knowledge Base & Documentation — build a structured wiki from code or notes
+7. Knowledge Base & Documentation — build a structured wiki from code or notes (OKF v0.1 bundle)
 8. Content Voice — brand voice + per-platform tone rules (not a full content workflow)
 
 _Tip: if you both read papers and write a manuscript in this repo, pick option 6 (research) first — it detects a manuscript folder and offers to cascade into option 5 (academic-writing) automatically._


### PR DESCRIPTION
## What

Aligns the `knowledge-base-setup` wiki with Google Cloud's **Open Knowledge Format (OKF v0.1)** — the published, vendor-neutral standard that formalizes the Karpathy LLM-wiki pattern. Generated bundles become portable across any OKF-aware agent or tool, at no cost to the existing workflow.

Spec: https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md

## Changes

- **Concept note format → OKF frontmatter.** YAML frontmatter with a required `type` plus recommended `title` / `description` / `resource` / `tags` (list) / `timestamp`, replacing the ad-hoc inline `tags:` line and `## Related: [[wikilink]]` footer.
- **Links → Markdown, not wikilinks.** Canonical cross-links are standard Markdown links (bundle-relative or relative). Wikilinks become an optional Obsidian-only convenience.
- **Reserved files seeded.** Setup creates `wiki/index.md` (directory listing, no frontmatter) and `wiki/log.md` (chronological history) so the bundle is conformant from the first commit; ingestion keeps both current and runs an OKF conformance self-check.
- **Modularization.** OKF skeletons, linking rule, `type` vocabulary, self-check, and Obsidian reconciliation extracted to the new sibling `skills/knowledge-base-setup/document-skeletons.md` (SKILL.md was over the 300-line threshold).
- **Subagent.** `obsidian-vault-keeper` and the `obsidian-cli` reference require a non-empty `type` on every new note.
- **Anchor.** `docs/anchors/knowledge-base.md` reframed around OKF frontmatter; OKF spec + Google Cloud blog added to its sources; `version: 2`.
- **Docs / manifest.** README (Pick your path / What's Inside / What gets generated / knowledge-base section), onboarding menu, RELEASE-NOTES (v1.3.0), design spec; plugin version bumped to 1.3.0.

## Scope boundary

`graphify-setup` builds a knowledge *graph* (a queryable index), not an LLM-wiki, so OKF does not apply — documented in the design spec rather than force-fitted.

## Verification

- `scripts/check-consistency.sh` passes
- `knowledge-base-setup` trigger eval: 10/10 (100%)
- `plugin.json` valid JSON

## Research

OKF conformance requirements were cross-verified via a multi-source workflow against the official spec, the reference bundles in `GoogleCloudPlatform/knowledge-catalog`, the Google Cloud announcement blog, and independent explainers.